### PR TITLE
ローカル音楽再生アプリの作成：バグ修正、アクセス許可確認の追加

### DIFF
--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -26,6 +26,39 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3pB-FD-u7X">
+                                <rect key="frame" x="111" y="258" width="31" height="33"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="再生"/>
+                                <connections>
+                                    <action selector="playButton:" destination="9pv-A4-QxB" eventType="touchUpInside" id="H2I-B0-LKY"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1ua-FF-b2v">
+                                <rect key="frame" x="189" y="261" width="62" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="一時停止"/>
+                                <connections>
+                                    <action selector="pauseButton:" destination="9pv-A4-QxB" eventType="touchUpInside" id="YAp-6z-hyI"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hze-6u-r32">
+                                <rect key="frame" x="305" y="261" width="31" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="停止"/>
+                                <connections>
+                                    <action selector="stopButton:" destination="9pv-A4-QxB" eventType="touchUpInside" id="2D2-nd-cwH"/>
+                                    <action selector="stopButtoon:" destination="9pv-A4-QxB" eventType="touchUpInside" id="PZG-Pe-eIh"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DlF-Xy-dAJ">
+                                <rect key="frame" x="159" y="350" width="123" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="ライブラリを開く"/>
+                                <connections>
+                                    <action selector="jumpToLibraryButton:" destination="9pv-A4-QxB" eventType="touchUpInside" id="0FB-Hk-0jL"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
@@ -40,7 +73,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="W5J-7L-Pyd" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="750" y="-320"/>
+            <point key="canvasLocation" x="749.27536231884062" y="-320.08928571428572"/>
         </scene>
         <!--Second-->
         <scene sceneID="wg7-f3-ORb">
@@ -97,7 +130,7 @@
         </scene>
     </scenes>
     <resources>
-        <image name="magnifyingglass" catalog="system" width="64" height="60"/>
-        <image name="music.note.list" catalog="system" width="64" height="58"/>
+        <image name="magnifyingglass" catalog="system" width="64" height="56"/>
+        <image name="music.note.list" catalog="system" width="64" height="56"/>
     </resources>
 </document>

--- a/DJYusaku/FirstViewController.swift
+++ b/DJYusaku/FirstViewController.swift
@@ -7,14 +7,50 @@
 //
 
 import UIKit
+import MediaPlayer
 
-class FirstViewController: UIViewController {
-
+class ViewController: UIViewController, MPMediaPickerControllerDelegate {
+    
+    var player :MPMusicPlayerController!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
+        // Do any additional setup after loading the view, typically from a nib.
+        player = MPMusicPlayerController.applicationMusicPlayer
     }
 
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
 
+    @IBAction func jumpToLibraryButton(_ sender: Any) {
+        let picker = MPMediaPickerController()
+        picker.delegate = self
+        picker.allowsPickingMultipleItems = true
+        present(picker, animated: true, completion: nil)
+    }
+    func mediaPicker(_ mediaPicker: MPMediaPickerController, didPickMediaItems mediaItemCollection: MPMediaItemCollection) {
+        player.setQueue(with: mediaItemCollection)
+        player.play()
+        dismiss(animated: true, completion: nil)
+    }
+    func mediaPickerDidCancel(_ mediaPicker: MPMediaPickerController) {
+        
+        dismiss(animated: true, completion: nil)
+    }
+    @IBAction func playButton(_ sender: Any) {
+//        print("play")
+        player.play()
+    }
+    
+    @IBAction func pauseButton(_ sender: Any) {
+//        print("pause")
+        player.pause()
+    }
+    
+    @IBAction func stopButton(_ sender: Any) {
+//        print("stop")
+        player.stop()
+    }
 }
-

--- a/DJYusaku/FirstViewController.swift
+++ b/DJYusaku/FirstViewController.swift
@@ -9,34 +9,62 @@
 import UIKit
 import MediaPlayer
 
-class ViewController: UIViewController, MPMediaPickerControllerDelegate {
+class FirstViewController: UIViewController, MPMediaPickerControllerDelegate {
     
-    var player :MPMusicPlayerController!
+    var player = MPMusicPlayerController.applicationMusicPlayer
+    let picker = MPMediaPickerController()
+    let permissionStatus = MPMediaLibrary.authorizationStatus()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
-        player = MPMusicPlayerController.applicationMusicPlayer
     }
 
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
+    
+    func displayPermissionAlert(){
+        let alert = UIAlertController(
+            title: "アクセス許可の要求",
+            message: "設定->DJ-YUSAKUを開いて、「メディアとAppleMusic」へのアクセス許可をしてください",
+            preferredStyle: .alert
+        )
+        alert.popoverPresentationController?.sourceView = self.view
+        
+        alert.addAction(UIAlertAction(title: "許可しない", style: .default, handler: nil))
+        
+        
+        let openSettingsAction = UIAlertAction(title: "「設定」を開く", style: .default){ _ in
+            if let url = URL(string: UIApplication.openSettingsURLString) {
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            }
+        }
+        alert.addAction(openSettingsAction)
+        
+        self.presentedViewController?.dismiss(animated: false, completion: nil)
+        present(alert, animated: true, completion: nil)
+        
+    }
 
     @IBAction func jumpToLibraryButton(_ sender: Any) {
-        let picker = MPMediaPickerController()
-        picker.delegate = self
-        picker.allowsPickingMultipleItems = true
-        present(picker, animated: true, completion: nil)
+        if(permissionStatus == .denied || permissionStatus == .restricted){
+            displayPermissionAlert()
+        }else{
+            picker.delegate = self
+            picker.allowsPickingMultipleItems = true
+            present(picker, animated: true, completion: nil)
+        }
     }
+    
     func mediaPicker(_ mediaPicker: MPMediaPickerController, didPickMediaItems mediaItemCollection: MPMediaItemCollection) {
         player.setQueue(with: mediaItemCollection)
         player.play()
         dismiss(animated: true, completion: nil)
     }
+    
     func mediaPickerDidCancel(_ mediaPicker: MPMediaPickerController) {
-        
         dismiss(animated: true, completion: nil)
     }
     @IBAction func playButton(_ sender: Any) {

--- a/DJYusaku/Info.plist
+++ b/DJYusaku/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppleMusicUsageDescription</key>
+	<string>音楽ライブラリへのアクセスの要求</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
#1 の修正
## 概要
先日の@yaplusの指摘から、バグの修正とメディアライブラリへのアクセス許可の確認に関する処理を追加

## 変更点
- クラス名をViewController -> FirstViewControllerに訂正
- Info.plistにNSAppleMusicUsageDescriptionを追加
- メディアライブラリへのアクセス許可がない時に、設定画面から「メディアとAppleMusic」へのアクセス許可を行うためのアラートを追加（詳細は後述）

## アラートについて
本来の要求から若干実装を変更した

> メディアライブラリへのアクセスを行うための許可をFirstViewの読み込み時に確認

viewDidLoadにMPMediaLibrary.authorizationStatus()の値によってアラートを表示させようとした
（notDetermined, denied, restrictedの場合）

起動時にアラートが出ない（おそらく理解不足）ので変更
「ライブラリ」ボタン押下時のイベントjumpToLibraryButton()に当該の処理を追加
アラートを表示する処理はdisplayPermissionAlert()に記載

## できていること
- シミュレータ（iPhone11, 11 Max）上で「ライブラリ」ボタンを押した際にアラートが出現することは確認済み

## 参考
- https://developer.apple.com/documentation/mediaplayer/mpmedialibraryauthorizationstatus
- https://stackoverflow.com/questions/40714988/checking-authorizations-for-mpmedialibrary-in-swift-3
- http://ichigoryume.hateblo.jp/entry/2018/09/06/102331

また、今回のアラート部分の実装がiPad上で問題となる可能性あり
-  https://develop.hateblo.jp/entry/ipad-uialertcontroller-actionsheet