### PR TITLE
Apple Musicからの楽曲検索機能の追加

### DIFF
--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -471,13 +471,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = F98SMB4597;
+				DEVELOPMENT_TEAM = 29WP3DF4XR;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.leney;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -489,13 +489,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = F98SMB4597;
+				DEVELOPMENT_TEAM = 29WP3DF4XR;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.leney;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B125D88D235F426C00D383E7 /* Artwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = B125D88C235F426C00D383E7 /* Artwork.swift */; };
 		C436A8562350B16B009F6498 /* MusicDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C436A8552350B16B009F6498 /* MusicDataModel.swift */; };
 		C436A8582350D36F009F6498 /* SearchMusicTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C436A8572350D36F009F6498 /* SearchMusicTableViewCell.swift */; };
 		C447ACA6234882F900D535EB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C447ACA5234882F900D535EB /* AppDelegate.swift */; };
@@ -42,6 +43,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B125D88C235F426C00D383E7 /* Artwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artwork.swift; sourceTree = "<group>"; };
 		C436A8552350B16B009F6498 /* MusicDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicDataModel.swift; sourceTree = "<group>"; };
 		C436A8572350D36F009F6498 /* SearchMusicTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchMusicTableViewCell.swift; sourceTree = "<group>"; };
 		C447ACA2234882F900D535EB /* DJYusaku.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DJYusaku.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -126,6 +128,7 @@
 				C4D25957235205D10066FCE0 /* Secrets.swift */,
 				C4D25959235205EC0066FCE0 /* Secrets+Local.swift */,
 				C4FDD0CB2356EA8F007569B1 /* RequestsMusicTableViewCell.swift */,
+				B125D88C235F426C00D383E7 /* Artwork.swift */,
 			);
 			path = DJYusaku;
 			sourceTree = "<group>";
@@ -285,6 +288,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B125D88D235F426C00D383E7 /* Artwork.swift in Sources */,
 				C4CF9725235163EF00C8A102 /* SearchViewController.swift in Sources */,
 				C4FDD0CC2356EA8F007569B1 /* RequestsMusicTableViewCell.swift in Sources */,
 				C436A8562350B16B009F6498 /* MusicDataModel.swift in Sources */,
@@ -467,13 +471,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 29WP3DF4XR;
+				DEVELOPMENT_TEAM = F98SMB4597;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.leney;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -485,13 +489,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 29WP3DF4XR;
+				DEVELOPMENT_TEAM = F98SMB4597;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.leney;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -17,6 +17,7 @@
 		C447ACB4234882FB00D535EB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C447ACB2234882FB00D535EB /* LaunchScreen.storyboard */; };
 		C447ACBF234882FB00D535EB /* DJYusakuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C447ACBE234882FB00D535EB /* DJYusakuTests.swift */; };
 		C447ACCA234882FB00D535EB /* DJYusakuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C447ACC9234882FB00D535EB /* DJYusakuUITests.swift */; };
+		C4A3C95A2357E908005304AA /* SwiftyJSON in Frameworks */ = {isa = PBXBuildFile; productRef = C4A3C9592357E908005304AA /* SwiftyJSON */; };
 		C4CF9725235163EF00C8A102 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4CF9724235163EF00C8A102 /* SearchViewController.swift */; };
 		C4D25958235205D10066FCE0 /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D25957235205D10066FCE0 /* Secrets.swift */; };
 		C4D2595A235205EC0066FCE0 /* Secrets+Local.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D25959235205EC0066FCE0 /* Secrets+Local.swift */; };
@@ -68,6 +69,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C4A3C95A2357E908005304AA /* SwiftyJSON in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -162,6 +164,9 @@
 			dependencies = (
 			);
 			name = DJYusaku;
+			packageProductDependencies = (
+				C4A3C9592357E908005304AA /* SwiftyJSON */,
+			);
 			productName = DJYusaku;
 			productReference = C447ACA2234882F900D535EB /* DJYusaku.app */;
 			productType = "com.apple.product-type.application";
@@ -234,6 +239,9 @@
 				Base,
 			);
 			mainGroup = C447AC99234882F900D535EB;
+			packageReferences = (
+				C4A3C9582357E908005304AA /* XCRemoteSwiftPackageReference "SwiftyJSON" */,
+			);
 			productRefGroup = C447ACA3234882F900D535EB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -614,6 +622,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		C4A3C9582357E908005304AA /* XCRemoteSwiftPackageReference "SwiftyJSON" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SwiftyJSON/SwiftyJSON.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		C4A3C9592357E908005304AA /* SwiftyJSON */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C4A3C9582357E908005304AA /* XCRemoteSwiftPackageReference "SwiftyJSON" */;
+			productName = SwiftyJSON;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = C447AC9A234882F900D535EB /* Project object */;
 }

--- a/DJYusaku.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/DJYusaku.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:DJYusaku.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/DJYusaku.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DJYusaku.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SwiftyJSON",
+        "repositoryURL": "https://github.com/SwiftyJSON/SwiftyJSON.git",
+        "state": {
+          "branch": null,
+          "revision": "2b6054efa051565954e1d2b9da831680026cd768",
+          "version": "5.0.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/DJYusaku/Artwork.swift
+++ b/DJYusaku/Artwork.swift
@@ -11,25 +11,16 @@ import Foundation
 
 class Artwork {
     
-    //お試しのシングルトンのキャッシュ、あとで消す
-    //static let testCache = Artwork()
-    
-    //あとでprivateに直す
     private static var imageCache = NSCache<AnyObject, AnyObject>()
-    
-//    private init() {
-//        //write initialize code
-//    }
-    
-    // 任意のサイズのアートワーク用URLを生成(SearchViewControllerから移動)するクラス関数
-    static func artworkUrl(urlString: String, width: Int, height: Int) -> URL {
+
+    static func url(urlString: String, width: Int, height: Int) -> URL {
         let replaced = urlString.replacingOccurrences(of: "{w}", with: "\(width)")
                                 .replacingOccurrences(of: "{h}", with: "\(height)")
         return URL(string: replaced)!
     }
-    // URLを受け取ってキャッシュに保存してUIImageに変換する
-    static func cacheProcessing(url: URL) -> UIImage? {
-        var artworkImage: UIImage?
+    
+    static func fetch(url: URL) -> UIImage? {
+        var artworkImage: UIImage? = nil
         if let imageData = imageCache.object(forKey: url as AnyObject){
             artworkImage = UIImage(data: imageData as! Data)
             return artworkImage

--- a/DJYusaku/Artwork.swift
+++ b/DJYusaku/Artwork.swift
@@ -30,17 +30,17 @@ class Artwork {
     // URLを受け取ってキャッシュに保存してUIImageに変換する
     static func cacheProcessing(url: URL) -> UIImage? {
         var returnUIImage: UIImage?
-         if let imageData = imageCache.object(forKey: url as AnyObject){
+        if let imageData = imageCache.object(forKey: url as AnyObject){
             returnUIImage = UIImage(data: imageData as! Data)
         }
          else {
-        let downloadTask = URLSession.shared.dataTask(with: url) { data, _, error in
-        if let error = error {
-            print(error)
-            return
+            let downloadTask = URLSession.shared.dataTask(with: url) { data, _, error in
+                if let error = error {
+                    print(error)
+                    return
             }
-            imageCache.setObject(data as AnyObject, forKey: url as AnyObject)
-            returnUIImage = UIImage(data: data!)
+                imageCache.setObject(data as AnyObject, forKey: url as AnyObject)
+                returnUIImage = UIImage(data: data!)
             }
             downloadTask.resume()
         }

--- a/DJYusaku/Artwork.swift
+++ b/DJYusaku/Artwork.swift
@@ -1,0 +1,29 @@
+//
+//  Artwork.swift
+//  DJYusaku
+//
+//  Created by leney on 2019/10/22.
+//  Copyright © 2019 Yusaku. All rights reserved.
+//
+
+import Foundation
+
+final class Artwork: NSCache<AnyObject, AnyObject> {
+    
+    //お試しのシングルトンのキャッシュ、あとで消す
+    static let testCache = Artwork()
+    
+    //お試しのキャッシュ、あとで消す
+    //static let imageCache = NSCache<AnyObject, AnyObject>()
+    
+    private override init() {
+        //write initialize code
+    }
+    
+    // 任意のサイズのアートワーク用URLを生成(SearchViewControllerから移動)するクラス関数
+    static func artworkUrl(urlString: String, width: Int, height: Int) -> URL {
+        let replaced = urlString.replacingOccurrences(of: "{w}", with: "\(width)")
+                                .replacingOccurrences(of: "{h}", with: "\(height)")
+        return URL(string: replaced)!
+    }
+}

--- a/DJYusaku/Artwork.swift
+++ b/DJYusaku/Artwork.swift
@@ -6,24 +6,44 @@
 //  Copyright © 2019 Yusaku. All rights reserved.
 //
 
+import UIKit
 import Foundation
 
-final class Artwork: NSCache<AnyObject, AnyObject> {
+class Artwork {
     
     //お試しのシングルトンのキャッシュ、あとで消す
-    static let testCache = Artwork()
+    //static let testCache = Artwork()
     
-    //お試しのキャッシュ、あとで消す
-    //static let imageCache = NSCache<AnyObject, AnyObject>()
+    //あとでprivateに直す
+    static var imageCache = NSCache<AnyObject, AnyObject>()
     
-    private override init() {
-        //write initialize code
-    }
+//    private init() {
+//        //write initialize code
+//    }
     
     // 任意のサイズのアートワーク用URLを生成(SearchViewControllerから移動)するクラス関数
     static func artworkUrl(urlString: String, width: Int, height: Int) -> URL {
         let replaced = urlString.replacingOccurrences(of: "{w}", with: "\(width)")
                                 .replacingOccurrences(of: "{h}", with: "\(height)")
         return URL(string: replaced)!
+    }
+    // URLを受け取ってキャッシュに保存してUIImageに変換する
+    static func cacheProcessing(url: URL) -> UIImage? {
+        var returnUIImage: UIImage?
+         if let imageData = imageCache.object(forKey: url as AnyObject){
+            returnUIImage = UIImage(data: imageData as! Data)
+        }
+         else {
+        let downloadTask = URLSession.shared.dataTask(with: url) { data, _, error in
+        if let error = error {
+            print(error)
+            return
+            }
+            imageCache.setObject(data as AnyObject, forKey: url as AnyObject)
+            returnUIImage = UIImage(data: data!)
+            }
+            downloadTask.resume()
+        }
+        return returnUIImage
     }
 }

--- a/DJYusaku/Artwork.swift
+++ b/DJYusaku/Artwork.swift
@@ -15,7 +15,7 @@ class Artwork {
     //static let testCache = Artwork()
     
     //あとでprivateに直す
-    static var imageCache = NSCache<AnyObject, AnyObject>()
+    private static var imageCache = NSCache<AnyObject, AnyObject>()
     
 //    private init() {
 //        //write initialize code
@@ -29,21 +29,18 @@ class Artwork {
     }
     // URLを受け取ってキャッシュに保存してUIImageに変換する
     static func cacheProcessing(url: URL) -> UIImage? {
-        var returnUIImage: UIImage?
+        var artworkImage: UIImage?
         if let imageData = imageCache.object(forKey: url as AnyObject){
-            returnUIImage = UIImage(data: imageData as! Data)
+            artworkImage = UIImage(data: imageData as! Data)
+            return artworkImage
         }
-         else {
-            let downloadTask = URLSession.shared.dataTask(with: url) { data, _, error in
-                if let error = error {
-                    print(error)
-                    return
-            }
-                imageCache.setObject(data as AnyObject, forKey: url as AnyObject)
-                returnUIImage = UIImage(data: data!)
-            }
-            downloadTask.resume()
+        do {
+            let imageData = try Data(contentsOf: url)
+            imageCache.setObject(imageData as AnyObject, forKey: url as AnyObject)
+            artworkImage = UIImage(data: imageData)
+        } catch {
+            // TODO: 画像が取得できなかった際のエラーハンドリング
         }
-        return returnUIImage
+        return artworkImage
     }
 }

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -27,11 +27,12 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="music.note" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="4BI-ax-603">
-                                                    <rect key="frame" x="15" y="9" width="48" height="46.666666666666671"/>
+                                                    <rect key="frame" x="15" y="10.666666666666668" width="48" height="43.333333333333336"/>
                                                     <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="48" id="XMs-5I-DSO"/>
                                                     </constraints>
+                                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="small"/>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Music Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yug-k8-ppk">
                                                     <rect key="frame" x="71" y="11" width="288" height="20"/>
@@ -74,11 +75,12 @@
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="music.note" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Klr-Js-sjB">
-                                            <rect key="frame" x="15" y="13" width="48" height="46.666666666666671"/>
+                                            <rect key="frame" x="15" y="14.666666666666668" width="48" height="43.333333333333329"/>
                                             <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="48" id="WVt-yv-NOb"/>
                                             </constraints>
+                                            <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="small"/>
                                         </imageView>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sYe-8j-hTb">
                                             <rect key="frame" x="308" y="12" width="48" height="48"/>
@@ -174,11 +176,12 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="music.note" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="rYB-jY-hDQ">
-                                                    <rect key="frame" x="15" y="9" width="48" height="46.666666666666671"/>
+                                                    <rect key="frame" x="15" y="10.666666666666668" width="48" height="43.333333333333336"/>
                                                     <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="48" id="Pry-Xv-Br7"/>
                                                     </constraints>
+                                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="small"/>
                                                 </imageView>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sbi-3a-kYZ">
                                                     <rect key="frame" x="327" y="3" width="33" height="58"/>

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -26,8 +26,9 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Abbey Road" translatesAutoresizingMaskIntoConstraints="NO" id="4BI-ax-603">
-                                                    <rect key="frame" x="15" y="8" width="48" height="48"/>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="music.note" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="4BI-ax-603">
+                                                    <rect key="frame" x="15" y="9" width="48" height="46.666666666666671"/>
+                                                    <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="48" id="XMs-5I-DSO"/>
                                                     </constraints>
@@ -72,8 +73,9 @@
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="72"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Abbey Road" translatesAutoresizingMaskIntoConstraints="NO" id="Klr-Js-sjB">
-                                            <rect key="frame" x="15" y="12" width="48" height="48"/>
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="music.note" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Klr-Js-sjB">
+                                            <rect key="frame" x="15" y="13" width="48" height="46.666666666666671"/>
+                                            <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="48" id="WVt-yv-NOb"/>
                                             </constraints>
@@ -171,8 +173,9 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Abbey Road" translatesAutoresizingMaskIntoConstraints="NO" id="rYB-jY-hDQ">
-                                                    <rect key="frame" x="15" y="8" width="48" height="48"/>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="music.note" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="rYB-jY-hDQ">
+                                                    <rect key="frame" x="15" y="9" width="48" height="46.666666666666671"/>
+                                                    <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="48" id="Pry-Xv-Br7"/>
                                                     </constraints>
@@ -301,9 +304,9 @@
         </scene>
     </scenes>
     <resources>
-        <image name="Abbey Road" width="600" height="600"/>
         <image name="forward.fill" catalog="system" width="64" height="38"/>
         <image name="magnifyingglass" catalog="system" width="64" height="56"/>
+        <image name="music.note" catalog="system" width="48" height="64"/>
         <image name="music.note.list" catalog="system" width="64" height="56"/>
         <image name="person.2.fill" catalog="system" width="64" height="40"/>
         <image name="plus.circle" catalog="system" width="64" height="60"/>

--- a/DJYusaku/Info.plist
+++ b/DJYusaku/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSAppleMusicUsageDescription</key>
-	<string>Access to Apple Music Library</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -22,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppleMusicUsageDescription</key>
+	<string>Access to Apple Music Library</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/DJYusaku/MusicDataModel.swift
+++ b/DJYusaku/MusicDataModel.swift
@@ -9,13 +9,13 @@
 import UIKit
 
 struct MusicDataModel {
-    var title:  String // 曲名
-    var artist: String // アーティスト名
-    var artwork: UIImage // 画像アートワーク
+    var title:  String      // 曲名
+    var artist: String      // アーティスト名
+    var artworkUrl: URL     // 画像アートワーク
 
-    init(title: String, artist: String, artwork: UIImage){
+    init(title: String, artist: String, artworkUrl: URL){
         self.title   = title
         self.artist  = artist
-        self.artwork = artwork
+        self.artworkUrl = artworkUrl
     }
 }

--- a/DJYusaku/MusicDataModel.swift
+++ b/DJYusaku/MusicDataModel.swift
@@ -6,12 +6,16 @@
 //  Copyright © 2019 Yusaku. All rights reserved.
 //
 
+import UIKit
+
 struct MusicDataModel {
     var title:  String // 曲名
     var artist: String // アーティスト名
+    var artwork: UIImage // 画像アートワーク
 
-    init(title: String, artist: String){
-        self.title  = title
-        self.artist = artist
+    init(title: String, artist: String, artwork: UIImage){
+        self.title   = title
+        self.artist  = artist
+        self.artwork = artwork
     }
 }

--- a/DJYusaku/MusicDataModel.swift
+++ b/DJYusaku/MusicDataModel.swift
@@ -6,9 +6,7 @@
 //  Copyright © 2019 Yusaku. All rights reserved.
 //
 
-import UIKit
-
-class MusicDataModel : NSObject {
+struct MusicDataModel {
     var title:  String // 曲名
     var artist: String // アーティスト名
 

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -14,25 +14,7 @@ class RequestsViewController: UIViewController {
     @IBOutlet weak var playingTitle: UILabel!
     
     // 表示確認用サンプルデータ
-    var requests = [
-        MusicDataModel(title: "Come Together", artist: "The Beatles"),
-        MusicDataModel(title: "Something", artist: "The Beatles"),
-        MusicDataModel(title: "Maxwell's Silver Hammer", artist: "The Beatles"),
-        MusicDataModel(title: "Oh! Darling", artist: "The Beatles"),
-        MusicDataModel(title: "Octopus's Garden", artist: "The Beatles"),
-        MusicDataModel(title: "I Want You (She's So Heavy)", artist: "The Beatles"),
-        MusicDataModel(title: "Here Comes The Sun", artist: "The Beatles"),
-        MusicDataModel(title: "Because", artist: "The Beatles"),
-        MusicDataModel(title: "You Never Give Me Your Money", artist: "The Beatles"),
-        MusicDataModel(title: "Sun King", artist: "The Beatles"),
-        MusicDataModel(title: "Mean Mr. Mustard", artist: "The Beatles"),
-        MusicDataModel(title: "Polythene Pam", artist: "The Beatles"),
-        MusicDataModel(title: "She Came In Through The Bathroom Window", artist: "The Beatles"),
-        MusicDataModel(title: "Golden Slumbers", artist: "The Beatles"),
-        MusicDataModel(title: "Carry That Weight", artist: "The Beatles"),
-        MusicDataModel(title: "The End", artist: "The Beatles"),
-        MusicDataModel(title: "Her Majesty", artist: "The Beatles")
-    ]
+    private var requests : [MusicDataModel] = []
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -70,26 +70,12 @@ extension SearchViewController: UITableViewDataSource {
         cell.artwork.image = defaultArtwork
         
         DispatchQueue.global().async {
-                //let imageData = try Data(contentsOf: item.artworkUrl)
-                if let imageData = Artwork.imageCache.object(forKey: item.artworkUrl as AnyObject){
-                DispatchQueue.main.async {
-                    cell.artwork.image = UIImage(data: imageData as! Data)
-                    }}
-                else {
-                    let downloadTask = URLSession.shared.dataTask(with: item.artworkUrl) { [weak self] data, _, error in
-                    if let error = error {
-                        print(error)
-                        return
-                    }
-                        
-                    Artwork.imageCache.setObject(data as AnyObject, forKey: item.artworkUrl as AnyObject)
-                    DispatchQueue.main.async {
-                        cell.artwork.image = UIImage(data: data!)
-                        }
-                    }
-                    downloadTask.resume()
+            let imageData = Artwork.cacheProcessing(url: item.artworkUrl)
+            DispatchQueue.main.async {
+                cell.artwork.image = imageData
+                cell.artwork.setNeedsDisplay()
                 }
-        }
+            }
         return cell
     }
 }

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -73,9 +73,8 @@ extension SearchViewController: UITableViewDataSource {
             let imageData = Artwork.cacheProcessing(url: item.artworkUrl)
             DispatchQueue.main.async {
                 cell.artwork.image = imageData
-                cell.artwork.setNeedsDisplay()
-                }
             }
+        }
         return cell
     }
 }
@@ -118,17 +117,9 @@ extension SearchViewController: UISearchResultsUpdating {
                 completion(nil)
             }
         }
-        
         // 検索の実行
         task.resume()
     }
-    
-//    // 任意のサイズのアートワーク用URLを生成
-//    func artworkUrl(urlString: String, width: Int, height: Int) -> URL {
-//        let replaced = urlString.replacingOccurrences(of: "{w}", with: "\(width)")
-//                                .replacingOccurrences(of: "{h}", with: "\(height)")
-//        return URL(string: replaced)!
-//    }
     
     func updateSearchResults(for searchController: UISearchController) {
         // 検索文字列の取得
@@ -150,7 +141,7 @@ extension SearchViewController: UISearchResultsUpdating {
                 return
             }
             
-            DispatchQueue.main.async {
+            DispatchQueue.global().async {
                 self.results.removeAll()
                 for (_, song):(String, JSON) in songs {
                     let title            = song["attributes"]["name"].stringValue
@@ -159,7 +150,12 @@ extension SearchViewController: UISearchResultsUpdating {
                     let artworkUrl = Artwork.artworkUrl(urlString: artworkUrlString, width: 256, height: 256)
                     self.results.append(MusicDataModel(title: title, artist: artist, artworkUrl: artworkUrl))
                 }
-                self.tableView.reloadData()
+                DispatchQueue.main.async {
+                    //今のserachBarの内容と矛盾しないならtableViewの更新
+                    if searchText == searchController.searchBar.text {
+                        self.tableView.reloadData()
+                    }
+                }
             }
         }
     }

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -141,21 +141,19 @@ extension SearchViewController: UISearchResultsUpdating {
                 return
             }
             
-            DispatchQueue.global().async {
-                self.results.removeAll()
-                for (_, song):(String, JSON) in songs {
-                    let title            = song["attributes"]["name"].stringValue
-                    let artist           = song["attributes"]["artistName"].stringValue
-                    let artworkUrlString = song["attributes"]["artwork"]["url"].stringValue
-                    let artworkUrl = Artwork.artworkUrl(urlString: artworkUrlString, width: 256, height: 256)
-                    self.results.append(MusicDataModel(title: title, artist: artist, artworkUrl: artworkUrl))
-                }
-                DispatchQueue.main.async {
-                    //今のserachBarの内容と矛盾しないならtableViewの更新
-                    if searchText == searchController.searchBar.text {
-                        self.tableView.reloadData()
+            DispatchQueue.main.async {
+                //今のserachBarの内容と矛盾しないならself.resultsの更新
+                if searchText == searchController.searchBar.text {
+                    self.results.removeAll()
+                    for (_, song):(String, JSON) in songs {
+                        let title            = song["attributes"]["name"].stringValue
+                        let artist           = song["attributes"]["artistName"].stringValue
+                        let artworkUrlString = song["attributes"]["artwork"]["url"].stringValue
+                        let artworkUrl = Artwork.artworkUrl(urlString: artworkUrlString, width: 256, height: 256)
+                        self.results.append(MusicDataModel(title: title, artist: artist, artworkUrl: artworkUrl))
                     }
                 }
+                self.tableView.reloadData()
             }
         }
     }

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -66,15 +66,17 @@ extension SearchViewController: UITableViewDataSource {
         let item = results[indexPath.row]
         cell.title.text    = item.title
         cell.artist.text   = item.artist
-        cell.artwork.image = UIImage()
-
-        do {
-            let imageData = try Data(contentsOf: item.artworkUrl)
-            cell.artwork.image = UIImage(data: imageData)!
-            cell.setNeedsLayout()
-        } catch let error {
-            print("cannot create artwork UIImage : \(error.localizedDescription)")
-            
+        DispatchQueue.global().async {
+            do {
+                let imageData = try Data(contentsOf: item.artworkUrl)
+                DispatchQueue.main.async {
+                    cell.artwork.image = UIImage(data: imageData)!
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    cell.artwork.image = UIImage()
+                }
+            }
         }
         return cell
     }

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -17,13 +17,6 @@ class SearchViewController: UIViewController {
     private var storefrontCountryCode : String? = nil
     private var results : [MusicDataModel] = []
     private let defaultArtwork : UIImage = UIImage()
-    //キャッシュ回数をカウントするテスト用変数(あとで消す)
-    class GlobalVar {
-        private init() {}
-        static let shared = GlobalVar()
-
-        var count = 0
-    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -78,7 +71,7 @@ extension SearchViewController: UITableViewDataSource {
         
         DispatchQueue.global().async {
                 //let imageData = try Data(contentsOf: item.artworkUrl)
-                if let imageData = Artwork.testCache.object(forKey: item.artworkUrl as AnyObject){
+                if let imageData = Artwork.imageCache.object(forKey: item.artworkUrl as AnyObject){
                 DispatchQueue.main.async {
                     cell.artwork.image = UIImage(data: imageData as! Data)
                     }}
@@ -88,9 +81,8 @@ extension SearchViewController: UITableViewDataSource {
                         print(error)
                         return
                     }
-                    //テスト用のカウント変数
-                    var myCount: GlobalVar
-                    Artwork.testCache.setObject(data as AnyObject, forKey: item.artworkUrl as AnyObject)
+                        
+                    Artwork.imageCache.setObject(data as AnyObject, forKey: item.artworkUrl as AnyObject)
                     DispatchQueue.main.async {
                         cell.artwork.image = UIImage(data: data!)
                         }

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -70,9 +70,9 @@ extension SearchViewController: UITableViewDataSource {
         cell.artwork.image = defaultArtwork
         
         DispatchQueue.global().async {
-            let imageData = Artwork.cacheProcessing(url: item.artworkUrl)
+            let image = Artwork.fetch(url: item.artworkUrl)
             DispatchQueue.main.async {
-                cell.artwork.image = imageData
+                cell.artwork.image = image  // 画像の取得に失敗していたらnilが入ることに注意
             }
         }
         return cell
@@ -142,16 +142,17 @@ extension SearchViewController: UISearchResultsUpdating {
             }
             
             DispatchQueue.main.async {
-                //今のserachBarの内容と矛盾しないならself.resultsの更新
-                if searchText == searchController.searchBar.text {
-                    self.results.removeAll()
-                    for (_, song):(String, JSON) in songs {
-                        let title            = song["attributes"]["name"].stringValue
-                        let artist           = song["attributes"]["artistName"].stringValue
-                        let artworkUrlString = song["attributes"]["artwork"]["url"].stringValue
-                        let artworkUrl = Artwork.artworkUrl(urlString: artworkUrlString, width: 256, height: 256)
-                        self.results.append(MusicDataModel(title: title, artist: artist, artworkUrl: artworkUrl))
-                    }
+                // 今のserachBarの内容と矛盾していれば何もしない
+                let currentText = searchController.searchBar.text
+                guard searchText == currentText else { return }
+                
+                self.results.removeAll()
+                for (_, song):(String, JSON) in songs {
+                    let title            = song["attributes"]["name"].stringValue
+                    let artist           = song["attributes"]["artistName"].stringValue
+                    let artworkUrlString = song["attributes"]["artwork"]["url"].stringValue
+                    let artworkUrl = Artwork.url(urlString: artworkUrlString, width: 256, height: 256)
+                    self.results.append(MusicDataModel(title: title, artist: artist, artworkUrl: artworkUrl))
                 }
                 self.tableView.reloadData()
             }


### PR DESCRIPTION
## 概要

<img src="https://user-images.githubusercontent.com/3463901/67064842-03f91a00-f1a7-11e9-9d34-3ffb94cc2845.jpeg" height="562"> <img src="https://user-images.githubusercontent.com/3463901/67064836-fc397580-f1a6-11e9-88ae-c359de27dce1.PNG" height="562">

AppleMusicからの検索機能を実装した：
- [x] iCloudに接続できない場合はエラーダイアログが出る
- [x] 検索ワードからSearchMusicTableViewへの結果を出力する
- [x] アートワークが表示できる
- [x] 非同期処理したので比較的まともな速度で動く
- [x] 画像のキャッシュ（まだ）

画像キャッシュを実装するまで[WIP]にしておきます。マージはレビューが済んだ適当なタイミングで僕がやります。

**注意：** Secrets+Local.swiftにAppleMusicのDeveloper Tokenを定義していないとApple Musicの検索は動かないので、現時点で知っている @yaplus か @bldsky に「AirDropなどのインターネットを介しない手段で」教えてもらうこと。

## 既知の問題・気になってること

- 検索時に前に表示していたアートワークが残っている
  - アートワーク画像が取得できるまではプレースホルダを表示したい
- 問題が無い程度にエラーハンドリングはしているがあまり良くない（適当にnilをリターンして終わるなど）

## やってほしいこと

- 実機での動作確認
- SearchViewControllerのコードレビュー
- 上記の問題点についての意見をここに書く

