### PR TITLE
検索画面で選択した曲をリクエスト画面に追加する機能を実装

### DIFF
--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -475,13 +475,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 29WP3DF4XR;
+				DEVELOPMENT_TEAM = F98SMB4597;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.leney;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -492,8 +492,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = J87XZSWPMZ;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -501,6 +501,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/DJYusaku/RequestQueue.swift
+++ b/DJYusaku/RequestQueue.swift
@@ -27,7 +27,6 @@ class RequestQueue{
         requests.append(musicDataModel)
         //送る相手を指定していないため要修正
         NotificationCenter.default.post(name: .notifyName, object: nil)
-        print("2")
     }
     
     //requestsの中身を削除

--- a/DJYusaku/RequestQueue.swift
+++ b/DJYusaku/RequestQueue.swift
@@ -9,9 +9,8 @@
 import Foundation
 import UIKit
 
-//Notification.Nameをどこに書けばいいかまだ決まっていない
+
 extension Notification.Name {
-    static let searchCellToSearchVCName = Notification.Name("searchCellToSearchVcName")
     static let requestQueueToRequestsVCName = Notification.Name("requestQueueToRequestsVCName")
 }
 
@@ -20,28 +19,35 @@ class RequestQueue{
     
     static let shared = RequestQueue()
     
-    private var requests : [MusicDataModel] = []
-    // TODO: requestsの中身を追加する関数と消去する関数
-    
-    //requestsの中身を追加
-    func addRequest(musicDataModel: MusicDataModel){
-        requests.append(musicDataModel)
-        //RequestViewControllerにRequestQueueを追加できたことを通知
-        NotificationCenter.default.post(name: .requestQueueToRequestsVCName, object: nil)
+    private var requests : [MusicDataModel] = [] {
+        // requestsを監視、変更後に実行する
+        didSet {
+            // requestsが追加されたらRequestsVCに通知する
+            if requests.count > oldValue.count {
+                let title = requests[requests.count - 1].title
+                NotificationCenter.default.post(name: .requestQueueToRequestsVCName, object: nil, userInfo: ["title": title])
+            }
+        }
     }
     
-    //requestsの中身を削除
-    func deleteRequest(indexPath: Int){
-        requests.remove(at: indexPath)
+    // requestsの中身を追加する
+    func addRequest(request: MusicDataModel){
+        requests.append(request)
     }
     
-    //requestsの中身をカウントする
+    // requestsの中身を削除する
+    func removeRequest(index: Int){
+        requests.remove(at: index)
+    }
+    
+    // requestsの中身をカウントする
     func countRequests() -> Int {
         return requests.count
     }
     
-    //requestsの中身を取得する
-    func getRequest(indexPath: Int) -> MusicDataModel {
-        return requests[indexPath]
+    // requestsの中身を取得する
+    func getRequest(index: Int) -> MusicDataModel {
+        return requests[index]
     }
+
 }

--- a/DJYusaku/RequestQueue.swift
+++ b/DJYusaku/RequestQueue.swift
@@ -11,7 +11,8 @@ import UIKit
 
 //Notification.Nameをどこに書けばいいかまだ決まっていない
 extension Notification.Name {
-    static let sendRequestName = Notification.Name("sendRequestName")
+    static let searchCellToSearchVCName = Notification.Name("searchCellToSearchVcName")
+    static let requestQueueToRequestsVCName = Notification.Name("requestQueueToRequestsVCName")
 }
 
 class RequestQueue{
@@ -25,8 +26,8 @@ class RequestQueue{
     //requestsの中身を追加
     func addRequest(musicDataModel: MusicDataModel){
         requests.append(musicDataModel)
-        //送る相手を指定していないため要修正
-        NotificationCenter.default.post(name: .sendRequestName, object: nil)
+        //RequestViewControllerにRequestQueueを追加できたことを通知
+        NotificationCenter.default.post(name: .requestQueueToRequestsVCName, object: nil)
     }
     
     //requestsの中身を削除

--- a/DJYusaku/RequestQueue.swift
+++ b/DJYusaku/RequestQueue.swift
@@ -19,28 +19,28 @@ class RequestQueue{
     
     static let shared = RequestQueue()
     
-    private static var requests : [MusicDataModel] = []
+    private var requests : [MusicDataModel] = []
     // TODO: requestsの中身を追加する関数と消去する関数
     
     //requestsの中身を追加
-    static func addRequest(musicDataModel: MusicDataModel){
+    func addRequest(musicDataModel: MusicDataModel){
         requests.append(musicDataModel)
         //送る相手を指定していないため要修正
         NotificationCenter.default.post(name: .notifyName, object: nil)
     }
     
     //requestsの中身を削除
-    static func deleteRequest(indexPath: Int){
+    func deleteRequest(indexPath: Int){
         requests.remove(at: indexPath)
     }
     
     //requestsの中身をカウントする
-    static func countRequests() -> Int {
+    func countRequests() -> Int {
         return requests.count
     }
     
     //requestsの中身を取得する
-    static func getRequest(indexPath: Int) -> MusicDataModel {
+    func getRequest(indexPath: Int) -> MusicDataModel {
         return requests[indexPath]
     }
 }

--- a/DJYusaku/RequestQueue.swift
+++ b/DJYusaku/RequestQueue.swift
@@ -9,11 +9,39 @@
 import Foundation
 import UIKit
 
+//Notification.Nameをどこに書けばいいかまだ決まっていない
+extension Notification.Name {
+    static let notifyName = Notification.Name("notifyName")
+}
+
 class RequestQueue{
     private init(){}
     
     static let shared = RequestQueue()
     
-    private var requests : [MusicDataModel] = []
+    private static var requests : [MusicDataModel] = []
     // TODO: requestsの中身を追加する関数と消去する関数
+    
+    //requestsの中身を追加
+    static func addRequest(musicDataModel: MusicDataModel){
+        requests.append(musicDataModel)
+        //送る相手を指定していないため要修正
+        NotificationCenter.default.post(name: .notifyName, object: nil)
+        print("2")
+    }
+    
+    //requestsの中身を削除
+    static func deleteRequest(indexPath: Int){
+        requests.remove(at: indexPath)
+    }
+    
+    //requestsの中身をカウントする
+    static func countRequests() -> Int {
+        return requests.count
+    }
+    
+    //requestsの中身を取得する
+    static func getRequest(indexPath: Int) -> MusicDataModel {
+        return requests[indexPath]
+    }
 }

--- a/DJYusaku/RequestQueue.swift
+++ b/DJYusaku/RequestQueue.swift
@@ -11,7 +11,7 @@ import UIKit
 
 //Notification.Nameをどこに書けばいいかまだ決まっていない
 extension Notification.Name {
-    static let notifyName = Notification.Name("notifyName")
+    static let sendRequestName = Notification.Name("sendRequestName")
 }
 
 class RequestQueue{
@@ -26,7 +26,7 @@ class RequestQueue{
     func addRequest(musicDataModel: MusicDataModel){
         requests.append(musicDataModel)
         //送る相手を指定していないため要修正
-        NotificationCenter.default.post(name: .notifyName, object: nil)
+        NotificationCenter.default.post(name: .sendRequestName, object: nil)
     }
     
     //requestsの中身を削除

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -14,21 +14,6 @@ class RequestsViewController: UIViewController {
     @IBOutlet weak var playingArtwork: UIImageView!
     @IBOutlet weak var playingTitle: UILabel!
     
-    // 表示確認用サンプルデータ
-    private var requests = [
-        MusicDataModel(title: "Happier", artist: "Marshmello", artworkUrl: Artwork.url(urlString: "https://img.discogs.com/osP7UHCvBmZDrdIlpDgW6ifpaXU=/fit-in/600x595/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-13426814-1553984554-3921.png.jpg", width: 256, height: 256)),
-        MusicDataModel(title: "Billie Jean", artist: "Michael Jackson", artworkUrl: Artwork.url(urlString: "https://images-na.ssl-images-amazon.com/images/I/51Mz7YQ0e0L._AC_.jpg", width: 256, height: 256)),
-        MusicDataModel(title: "Pretender", artist: "Official髭男dism", artworkUrl: Artwork.url(urlString: "https://cdn.utaten.com/uploads/images/specialArticle/3909/thumbnail/0x800/591283d7ae5bae31c486e1babe0db1af6fffcfcf.jpeg", width: 256, height: 256)),
-        MusicDataModel(title: "MIND CONDUCTOR", artist: "YURiKA", artworkUrl: Artwork.url(urlString: "https://images-na.ssl-images-amazon.com/images/I/81aMFhI4G6L._AC_SL1500_.jpg", width: 256, height: 256)),
-        MusicDataModel(title: "留学生", artist: "MONKEY MAJIK × 岡崎体育", artworkUrl: Artwork.url(urlString: "https://images-na.ssl-images-amazon.com/images/I/61J8sAYJNuL._AC_SL1000_.jpg", width: 256, height: 256)),
-        MusicDataModel(title: "負け犬にアンコールはいらない", artist: "ヨルシカ", artworkUrl: Artwork.url(urlString: "https://images-na.ssl-images-amazon.com/images/I/81yDGHPwMfL._AC_SL1419_.jpg", width: 256, height: 256)),
-        MusicDataModel(title: "KISS OFLIFE", artist: "平井堅", artworkUrl: Artwork.url(urlString: "https://images-na.ssl-images-amazon.com/images/I/71XT%2BN5llOL._AC_SL1221_.jpg", width: 256, height: 256)),
-        MusicDataModel(title: "papa", artist: "Orange range", artworkUrl: Artwork.url(urlString: "https://images-na.ssl-images-amazon.com/images/I/61MIuaFTX0L._AC_.jpg", width: 256, height: 256)),
-        MusicDataModel(title: "Solar System", artist: "Sub Focus", artworkUrl: Artwork.url(urlString: "https://img.discogs.com/ZDQTTaoZDcoYhdnr1kvB9-3ow0k=/fit-in/600x600/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-13923579-1564159903-8551.jpeg.jpg", width: 256, height: 256)),
-        MusicDataModel(title: "ミツバチ", artist: "遊助", artworkUrl: Artwork.url(urlString: "https://images-na.ssl-images-amazon.com/images/I/51tx6bZYM8L._AC_.jpg", width: 256, height: 256)),
-        MusicDataModel(title: "September", artist: "Earth Wind & Fire", artworkUrl: Artwork.url(urlString: "https://cdn.utaten.com/uploads/images/specialArticle/446/thumbnail/0x800/image.jpeg", width: 256, height: 256)),
-        MusicDataModel(title: "Mr.Suicide", artist: "9mm Parabellum Bullet", artworkUrl: Artwork.url(urlString: "https://images-na.ssl-images-amazon.com/images/I/51CNfp1bYiL._AC_.jpg", width: 256, height: 256))
-    ]
     private let cloudServiceController = SKCloudServiceController()
     private let defaultArtwork : UIImage = UIImage()
     private var storefrontCountryCode : String? = nil
@@ -52,6 +37,13 @@ class RequestsViewController: UIViewController {
         
         playingArtwork.layer.cornerRadius = playingArtwork.frame.size.width * 0.05
         playingArtwork.clipsToBounds = true
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(updateRequests), name: .notifyName, object: nil)
+    }
+    
+    @objc func updateRequests(){
+        print("3")
+        tableView.reloadData()
     }
 }
 
@@ -59,13 +51,13 @@ class RequestsViewController: UIViewController {
 
 extension RequestsViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return requests.count
+        return RequestQueue.countRequests()
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "RequestsMusicTableViewCell", for: indexPath) as! RequestsMusicTableViewCell
         
-        let item = requests[indexPath.row]
+        let item = RequestQueue.getRequest(indexPath: indexPath.row)
         cell.title.text = item.title
         cell.artist.text = item.artist
         cell.artwork.image = defaultArtwork
@@ -88,7 +80,7 @@ extension RequestsViewController: UITableViewDelegate {
     // セルの編集時の挙動
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
-            requests.remove(at: indexPath.row)
+            RequestQueue.deleteRequest(indexPath: indexPath.row)
             tableView.deleteRows(at: [indexPath], with: .fade)
         }
     }

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -38,7 +38,7 @@ class RequestsViewController: UIViewController {
         playingArtwork.layer.cornerRadius = playingArtwork.frame.size.width * 0.05
         playingArtwork.clipsToBounds = true
         
-        NotificationCenter.default.addObserver(self, selector: #selector(updateRequests), name: .notifyName, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateRequests), name: .sendRequestName, object: nil)
     }
     
     @objc func updateRequests(){

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -38,15 +38,15 @@ class RequestsViewController: UIViewController {
         playingArtwork.layer.cornerRadius = playingArtwork.frame.size.width * 0.05
         playingArtwork.clipsToBounds = true
         
-        NotificationCenter.default.addObserver(self, selector: #selector(handleRequestUpdated), name: .requestQueueToRequestsVCName, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleRequestsUpdated), name: .requestQueueToRequestsVCName, object: nil)
     }
     
-    @objc func handleRequestUpdated(notification: NSNotification){
+    @objc func handleRequestsUpdated(notification: NSNotification){
         // リクエスト画面を更新
         DispatchQueue.main.async{
             self.tableView.reloadData()
         }
-        // リクエストが完了したAlertを表示
+        // リクエストが完了した旨のAlertを表示
         guard let title = notification.userInfo!["title"] as? String else { return }
         
         let alert = UIAlertController(title: title, message: "was Requested", preferredStyle: UIAlertController.Style.alert)

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -42,7 +42,6 @@ class RequestsViewController: UIViewController {
     }
     
     @objc func updateRequests(){
-        print("3")
         tableView.reloadData()
     }
 }

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -38,7 +38,7 @@ class RequestsViewController: UIViewController {
         playingArtwork.layer.cornerRadius = playingArtwork.frame.size.width * 0.05
         playingArtwork.clipsToBounds = true
         
-        NotificationCenter.default.addObserver(self, selector: #selector(updateRequests), name: .sendRequestName, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateRequests), name: .requestQueueToRequestsVCName, object: nil)
     }
     
     @objc func updateRequests(){

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -38,17 +38,15 @@ class RequestsViewController: UIViewController {
         playingArtwork.layer.cornerRadius = playingArtwork.frame.size.width * 0.05
         playingArtwork.clipsToBounds = true
         
-        NotificationCenter.default.addObserver(self, selector: #selector(updateRequests), name: .requestQueueToRequestsVCName, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleRequestUpdated), name: .requestQueueToRequestsVCName, object: nil)
     }
     
-    @objc func updateRequests(notification: NSNotification){
+    @objc func handleRequestUpdated(notification: NSNotification){
+        // リクエスト画面を更新
         DispatchQueue.main.async{
             self.tableView.reloadData()
         }
-        requestedAlert(notification: notification)
-    }
-    
-    func requestedAlert(notification: NSNotification){
+        // リクエストが完了したAlertを表示
         guard let title = notification.userInfo!["title"] as? String else { return }
         
         let alert = UIAlertController(title: title, message: "was Requested", preferredStyle: UIAlertController.Style.alert)

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -41,8 +41,21 @@ class RequestsViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(updateRequests), name: .requestQueueToRequestsVCName, object: nil)
     }
     
-    @objc func updateRequests(){
-        tableView.reloadData()
+    @objc func updateRequests(notification: NSNotification){
+        DispatchQueue.main.async{
+            self.tableView.reloadData()
+        }
+        requestedAlert(notification: notification)
+    }
+    
+    func requestedAlert(notification: NSNotification){
+        guard let title = notification.userInfo!["title"] as? String else { return }
+        
+        let alert = UIAlertController(title: title, message: "was Requested", preferredStyle: UIAlertController.Style.alert)
+
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+
+        present(alert, animated: true)
     }
 }
 
@@ -56,7 +69,7 @@ extension RequestsViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "RequestsMusicTableViewCell", for: indexPath) as! RequestsMusicTableViewCell
         
-        let item = RequestQueue.shared.getRequest(indexPath: indexPath.row)
+        let item = RequestQueue.shared.getRequest(index: indexPath.row)
         cell.title.text = item.title
         cell.artist.text = item.artist
         cell.artwork.image = defaultArtwork
@@ -79,7 +92,7 @@ extension RequestsViewController: UITableViewDelegate {
     // セルの編集時の挙動
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
-            RequestQueue.shared.deleteRequest(indexPath: indexPath.row)
+            RequestQueue.shared.removeRequest(index: indexPath.row)
             tableView.deleteRows(at: [indexPath], with: .fade)
         }
     }

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -50,13 +50,13 @@ class RequestsViewController: UIViewController {
 
 extension RequestsViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return RequestQueue.countRequests()
+        return RequestQueue.shared.countRequests()
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "RequestsMusicTableViewCell", for: indexPath) as! RequestsMusicTableViewCell
         
-        let item = RequestQueue.getRequest(indexPath: indexPath.row)
+        let item = RequestQueue.shared.getRequest(indexPath: indexPath.row)
         cell.title.text = item.title
         cell.artist.text = item.artist
         cell.artwork.image = defaultArtwork
@@ -79,7 +79,7 @@ extension RequestsViewController: UITableViewDelegate {
     // セルの編集時の挙動
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
-            RequestQueue.deleteRequest(indexPath: indexPath.row)
+            RequestQueue.shared.deleteRequest(indexPath: indexPath.row)
             tableView.deleteRows(at: [indexPath], with: .fade)
         }
     }

--- a/DJYusaku/SearchMusicTableViewCell.swift
+++ b/DJYusaku/SearchMusicTableViewCell.swift
@@ -15,6 +15,9 @@ class SearchMusicTableViewCell: UITableViewCell {
     @IBOutlet weak var artwork: UIImageView!
     @IBOutlet weak var button: UIButton!
     
+    //sendRequestに必要なURL型の変数(プライベート変数にするかも)
+    var artworkUrl: URL?
+    
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code
@@ -30,6 +33,7 @@ class SearchMusicTableViewCell: UITableViewCell {
         // Configure the view for the selected state
     }
     @IBAction func sendRequest(_ sender: Any) {
-//        requests.music.append(MusicDataModel(title: title.text, artist: artist.text, artworkUrl: artwork))
+        RequestQueue.addRequest(musicDataModel: MusicDataModel(title: title.text ?? "", artist: artist.text ?? "", artworkUrl: artworkUrl!))
+        print("yuyaKiuchi")
     }
 }

--- a/DJYusaku/SearchMusicTableViewCell.swift
+++ b/DJYusaku/SearchMusicTableViewCell.swift
@@ -34,6 +34,5 @@ class SearchMusicTableViewCell: UITableViewCell {
     }
     @IBAction func sendRequest(_ sender: Any) {
         RequestQueue.addRequest(musicDataModel: MusicDataModel(title: title.text ?? "", artist: artist.text ?? "", artworkUrl: artworkUrl!))
-        print("yuyaKiuchi")
     }
 }

--- a/DJYusaku/SearchMusicTableViewCell.swift
+++ b/DJYusaku/SearchMusicTableViewCell.swift
@@ -38,8 +38,6 @@ class SearchMusicTableViewCell: UITableViewCell {
         button.isEnabled = false
         //artworkUrlがnilなら追加されない
         guard let artworkUrl = artworkUrl else { return }
-        RequestQueue.shared.addRequest(musicDataModel: MusicDataModel(title: title.text ?? "", artist: artist.text ?? "", artworkUrl: artworkUrl))
-        //SearchViewControllerにボタンがタップされたことを通知
-        NotificationCenter.default.post(name: .searchCellToSearchVCName, object: nil, userInfo: ["title": self.title.text ?? "", "button": self.button as Any])
+        RequestQueue.shared.addRequest(request: MusicDataModel(title: title.text ?? "", artist: artist.text ?? "", artworkUrl: artworkUrl))
     }
 }

--- a/DJYusaku/SearchMusicTableViewCell.swift
+++ b/DJYusaku/SearchMusicTableViewCell.swift
@@ -32,7 +32,8 @@ class SearchMusicTableViewCell: UITableViewCell {
 
         // Configure the view for the selected state
     }
+    //+ボタンを押したらRequestsViewControllerに曲を追加する
     @IBAction func sendRequest(_ sender: Any) {
-        RequestQueue.addRequest(musicDataModel: MusicDataModel(title: title.text ?? "", artist: artist.text ?? "", artworkUrl: artworkUrl!))
+        RequestQueue.shared.addRequest(musicDataModel: MusicDataModel(title: title.text ?? "", artist: artist.text ?? "", artworkUrl: artworkUrl!))
     }
 }

--- a/DJYusaku/SearchMusicTableViewCell.swift
+++ b/DJYusaku/SearchMusicTableViewCell.swift
@@ -34,6 +34,8 @@ class SearchMusicTableViewCell: UITableViewCell {
     }
     //+ボタンを押したらRequestsViewControllerに曲を追加する
     @IBAction func sendRequest(_ sender: Any) {
-        RequestQueue.shared.addRequest(musicDataModel: MusicDataModel(title: title.text ?? "", artist: artist.text ?? "", artworkUrl: artworkUrl!))
+        //artworkUrlがnilなら追加されない
+        guard let artworkUrl = artworkUrl else { return }
+        RequestQueue.shared.addRequest(musicDataModel: MusicDataModel(title: title.text ?? "", artist: artist.text ?? "", artworkUrl: artworkUrl))
     }
 }

--- a/DJYusaku/SearchMusicTableViewCell.swift
+++ b/DJYusaku/SearchMusicTableViewCell.swift
@@ -34,8 +34,12 @@ class SearchMusicTableViewCell: UITableViewCell {
     }
     //+ボタンを押したらRequestsViewControllerに曲を追加する
     @IBAction func sendRequest(_ sender: Any) {
+        //ボタンを連続で押させないようにする
+        button.isEnabled = false
         //artworkUrlがnilなら追加されない
         guard let artworkUrl = artworkUrl else { return }
         RequestQueue.shared.addRequest(musicDataModel: MusicDataModel(title: title.text ?? "", artist: artist.text ?? "", artworkUrl: artworkUrl))
+        //SearchViewControllerにボタンがタップされたことを通知
+        NotificationCenter.default.post(name: .searchCellToSearchVCName, object: nil, userInfo: ["title": self.title.text ?? "", "button": self.button as Any])
     }
 }

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -51,20 +51,6 @@ class SearchViewController: UIViewController {
             }
             self.storefrontCountryCode = storefrontCountryCode
         }
-        NotificationCenter.default.addObserver(self, selector: #selector(registerRequestAlert), name: .searchCellToSearchVCName, object: nil)
-    }
-    @objc func registerRequestAlert(notification: NSNotification){
-        guard let userInfo = notification.userInfo else { return }
-
-        let title = userInfo["title"] as? String ?? ""
-        let button: UIButton! = userInfo["button"] as? UIButton
-        let alert = UIAlertController(title: title, message: "をリクエストしました", preferredStyle: UIAlertController.Style.alert)
-
-        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-
-        present(alert, animated: true)
-        
-        button.isEnabled = true
     }
 }
 
@@ -79,10 +65,11 @@ extension SearchViewController: UITableViewDataSource {
         let cell = tableView.dequeueReusableCell(withIdentifier: "SearchMusicTableViewCell", for: indexPath) as! SearchMusicTableViewCell
         
         let item = results[indexPath.row]
-        cell.title.text    = item.title
-        cell.artist.text   = item.artist
-        cell.artworkUrl = item.artworkUrl
-        cell.artwork.image = defaultArtwork
+        cell.title.text       = item.title
+        cell.artist.text      = item.artist
+        cell.artworkUrl       = item.artworkUrl
+        cell.artwork.image    = defaultArtwork
+        cell.button.isEnabled = true
         
         DispatchQueue.global().async {
             let image = Artwork.fetch(url: item.artworkUrl)

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -51,6 +51,20 @@ class SearchViewController: UIViewController {
             }
             self.storefrontCountryCode = storefrontCountryCode
         }
+        NotificationCenter.default.addObserver(self, selector: #selector(registerRequestAlert), name: .searchCellToSearchVCName, object: nil)
+    }
+    @objc func registerRequestAlert(notification: NSNotification){
+        guard let userInfo = notification.userInfo else { return }
+
+        let title = userInfo["title"] as? String ?? ""
+        let button: UIButton! = userInfo["button"] as? UIButton
+        let alert = UIAlertController(title: title, message: "をリクエストしました", preferredStyle: UIAlertController.Style.alert)
+
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+
+        present(alert, animated: true)
+        
+        button.isEnabled = true
     }
 }
 

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -67,6 +67,7 @@ extension SearchViewController: UITableViewDataSource {
         let item = results[indexPath.row]
         cell.title.text    = item.title
         cell.artist.text   = item.artist
+        cell.artworkUrl = item.artworkUrl
         cell.artwork.image = defaultArtwork
         
         DispatchQueue.global().async {


### PR DESCRIPTION
## 概要
<img src="https://user-images.githubusercontent.com/25448272/67591380-410d6f80-f798-11e9-9e0f-3143366ec37a.gif" width="280">
検索画面で+マークを押した曲をリクエスト画面に追加する機能を実装した

## 気になってる点
* Notification.Nameを今のところRequestQueue.swiftに書いているができれば設定用のファイルに書きたい(これは僕が知識不足なだけであるのかもしれない)
* NotificationCenterでtableView.reloadDataを呼ぶ関数を呼んでいるだけなのでもっといい書き方がありそう
* NotificationCenterの関数の引数に送り先のオブジェクトと受け取り先のオブジェクトを指定する引数をnilにしているがこれでいいらしい(調べてはいるがぼんやりしてます。情報ください)

## 問題点
* 検索画面で+ボタンを押したときのフィードバックがないので押されたかどうかわからない

## してほしいこと
* 曲の追加ができてるかどうか確認お願いします

## これからやろうとしていること
* +ボタンを押したときのフィードバックを付けます

## 参考
* [NotificationCenter Foundation | Apple Developer Documentation](https://developer.apple.com/documentation/foundation/notificationcenter)
* [【Swift】NotificationCenterの使い方 - Qiita](https://qiita.com/ryo-ta/items/2b142361996657463e5f)
* [NotificationCenter.addObserverのドキュメントがわからない - Qiita](https://qiita.com/eytyet/items/2690c570088a062b4afc)
* [Swiftとオブジェクト間の通知のパターン - Qiita](https://qiita.com/shtnkgm/items/f07f1c61985214ceb7b3)
