### PR TITLE
検索画面で選択された楽曲を、再生用のキューに追加・再生する機能の実装

### DIFF
--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -475,13 +475,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = F98SMB4597;
+				DEVELOPMENT_TEAM = J87XZSWPMZ;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.leney;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.amylase;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -499,7 +499,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.amylase;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -11,22 +12,22 @@
             <objects>
                 <viewController id="9pv-A4-QxB" customClass="RequestsViewController" customModule="DJYusaku" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tsR-hK-woN">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="64" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="2ub-dF-W8m">
-                                <rect key="frame" x="0.0" y="44" width="600" height="512"/>
+                                <rect key="frame" x="0.0" y="140" width="414" height="616"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="RequestsMusicTableViewCell" id="T5J-aV-tbm" customClass="RequestsMusicTableViewCell" customModule="DJYusaku" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="600" height="64"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="64"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="T5J-aV-tbm" id="Bkg-rZ-UB5">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="64"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="64"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="music.note" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="4BI-ax-603">
-                                                    <rect key="frame" x="15" y="10.5" width="48" height="43.5"/>
+                                                    <rect key="frame" x="20" y="10.5" width="48" height="43.5"/>
                                                     <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="48" id="XMs-5I-DSO"/>
@@ -34,13 +35,13 @@
                                                     <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="small"/>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Music Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yug-k8-ppk">
-                                                    <rect key="frame" x="71" y="11" width="513" height="20"/>
+                                                    <rect key="frame" x="76" y="11" width="322" height="20"/>
                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Artist" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hw4-hv-Z0J">
-                                                    <rect key="frame" x="71" y="33" width="513" height="20"/>
+                                                    <rect key="frame" x="76" y="33" width="322" height="20"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
@@ -68,9 +69,9 @@
                                 </prototypes>
                             </tableView>
                             <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1pJ-Iw-aHU">
-                                <rect key="frame" x="0.0" y="479" width="600" height="72"/>
+                                <rect key="frame" x="0.0" y="741" width="414" height="72"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="fET-Dx-yGV">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="72"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="72"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="music.note" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Klr-Js-sjB">
@@ -82,7 +83,7 @@
                                             <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="small"/>
                                         </imageView>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sYe-8j-hTb">
-                                            <rect key="frame" x="533" y="12" width="48" height="48"/>
+                                            <rect key="frame" x="347" y="12" width="48" height="48"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="48" id="i0p-CT-4s7"/>
                                             </constraints>
@@ -90,15 +91,18 @@
                                             <state key="normal" image="forward.fill" catalog="system">
                                                 <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="large"/>
                                             </state>
+                                            <connections>
+                                                <action selector="skip:" destination="9pv-A4-QxB" eventType="touchDown" id="m3p-ZR-kbX"/>
+                                            </connections>
                                         </button>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Music Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XGN-5n-Oha">
-                                            <rect key="frame" x="71" y="38" width="454" height="17"/>
+                                            <rect key="frame" x="71" y="38" width="268" height="17"/>
                                             <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Now Playing" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5jw-Pl-Uub">
-                                            <rect key="frame" x="71" y="17.5" width="454" height="20.5"/>
+                                            <rect key="frame" x="71" y="17.5" width="268" height="20.5"/>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                             <color key="textColor" systemColor="linkColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
@@ -148,6 +152,7 @@
                     <connections>
                         <outlet property="playingArtwork" destination="Klr-Js-sjB" id="pUO-iG-wKn"/>
                         <outlet property="playingTitle" destination="XGN-5n-Oha" id="bFZ-4V-axr"/>
+                        <outlet property="skipButton" destination="sYe-8j-hTb" id="ogy-la-KdG"/>
                         <outlet property="tableView" destination="2ub-dF-W8m" id="Bwj-iS-B5T"/>
                     </connections>
                 </viewController>
@@ -160,22 +165,22 @@
             <objects>
                 <viewController id="8rJ-Kc-sve" customClass="SearchViewController" customModule="DJYusaku" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="QS5-Rx-YEW">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="64" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="wCp-R2-0r7">
-                                <rect key="frame" x="0.0" y="44" width="600" height="507"/>
+                                <rect key="frame" x="0.0" y="140" width="414" height="673"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SearchMusicTableViewCell" id="Uxy-eD-cUw" customClass="SearchMusicTableViewCell" customModule="DJYusaku" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="600" height="64"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="64"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Uxy-eD-cUw" id="jsM-e1-0mc">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="64"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="64"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="music.note" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="rYB-jY-hDQ">
-                                                    <rect key="frame" x="15" y="10.5" width="48" height="43.5"/>
+                                                    <rect key="frame" x="20" y="10.5" width="48" height="43.5"/>
                                                     <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="48" id="Pry-Xv-Br7"/>
@@ -183,7 +188,7 @@
                                                     <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="small"/>
                                                 </imageView>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sbi-3a-kYZ">
-                                                    <rect key="frame" x="552" y="3" width="33" height="58"/>
+                                                    <rect key="frame" x="361" y="3" width="33" height="58"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="33" id="ZFb-13-njc"/>
                                                     </constraints>
@@ -195,13 +200,13 @@
                                                     </connections>
                                                 </button>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Music Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DxG-x9-Q3o">
-                                                    <rect key="frame" x="71" y="11" width="474" height="21"/>
+                                                    <rect key="frame" x="76" y="11" width="278" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Artist" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UVM-Kb-uf9">
-                                                    <rect key="frame" x="71" y="32" width="474" height="21"/>
+                                                    <rect key="frame" x="76" y="32" width="278" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
@@ -276,7 +281,7 @@
                     <tabBarItem key="tabBarItem" title="Search" image="magnifyingglass" catalog="system" id="cPa-gy-q4n"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="t5Y-gP-1Ll">
-                        <rect key="frame" x="0.0" y="44" width="375" height="96"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -295,7 +300,7 @@
                     <tabBarItem key="tabBarItem" title="Requests" image="music.note.list" catalog="system" id="acW-dT-cKf"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="NXp-M8-OkR">
-                        <rect key="frame" x="0.0" y="44" width="375" height="96"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/DJYusaku/Info.plist
+++ b/DJYusaku/Info.plist
@@ -41,6 +41,10 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/DJYusaku/MusicDataModel.swift
+++ b/DJYusaku/MusicDataModel.swift
@@ -12,7 +12,7 @@ struct MusicDataModel {
     var title:  String      // 曲名
     var artist: String      // アーティスト名
     var artworkUrl: URL     // 画像アートワーク
-    var songID : UInt64     // 曲のID
+    var songID : UInt64     // 曲のID（曲のpersistentIDとして再生時に使用したい）
 
     init(title: String, artist: String, artworkUrl: URL, songID: UInt64){
         self.title   = title

--- a/DJYusaku/MusicDataModel.swift
+++ b/DJYusaku/MusicDataModel.swift
@@ -12,10 +12,12 @@ struct MusicDataModel {
     var title:  String      // 曲名
     var artist: String      // アーティスト名
     var artworkUrl: URL     // 画像アートワーク
+    var songID : UInt64     // 曲のID
 
-    init(title: String, artist: String, artworkUrl: URL){
+    init(title: String, artist: String, artworkUrl: URL, songID: UInt64){
         self.title   = title
         self.artist  = artist
         self.artworkUrl = artworkUrl
+        self.songID = songID
     }
 }

--- a/DJYusaku/MusicDataModel.swift
+++ b/DJYusaku/MusicDataModel.swift
@@ -12,9 +12,9 @@ struct MusicDataModel {
     var title:  String      // 曲名
     var artist: String      // アーティスト名
     var artworkUrl: URL     // 画像アートワーク
-    var songID : UInt64     // 曲のID（曲のpersistentIDとして再生時に使用したい）
+    var songID : String    // 曲のID
 
-    init(title: String, artist: String, artworkUrl: URL, songID: UInt64){
+    init(title: String, artist: String, artworkUrl: URL, songID: String){
         self.title   = title
         self.artist  = artist
         self.artworkUrl = artworkUrl

--- a/DJYusaku/MusicDataModel.swift
+++ b/DJYusaku/MusicDataModel.swift
@@ -12,7 +12,7 @@ struct MusicDataModel {
     var title:  String      // 曲名
     var artist: String      // アーティスト名
     var artworkUrl: URL     // 画像アートワーク
-    var songID : String    // 曲のID
+    var songID : String     // 曲のID
 
     init(title: String, artist: String, artworkUrl: URL, songID: String){
         self.title   = title

--- a/DJYusaku/RequestQueue.swift
+++ b/DJYusaku/RequestQueue.swift
@@ -26,6 +26,7 @@ class RequestQueue{
             if requests.count > oldValue.count {
                 let title = requests[requests.count - 1].title
                 NotificationCenter.default.post(name: .requestQueueToRequestsVCName, object: nil, userInfo: ["title": title])
+                // TODO: [amylase] RequestsViewControllerにsongIDを追加で渡す
             }
         }
     }

--- a/DJYusaku/RequestQueue.swift
+++ b/DJYusaku/RequestQueue.swift
@@ -30,7 +30,6 @@ class RequestQueue{
             }
         }
     }
-    var nowPlayingIndex : Int = 0 
     // requestsの中身を追加する
     func addRequest(request: MusicDataModel){
         requests.append(request)

--- a/DJYusaku/RequestQueue.swift
+++ b/DJYusaku/RequestQueue.swift
@@ -30,7 +30,7 @@ class RequestQueue{
             }
         }
     }
-    
+    var nowPlayingIndex : Int = 0 
     // requestsの中身を追加する
     func addRequest(request: MusicDataModel){
         requests.append(request)

--- a/DJYusaku/RequestQueue.swift
+++ b/DJYusaku/RequestQueue.swift
@@ -24,9 +24,9 @@ class RequestQueue{
         didSet {
             // requestsが追加されたらRequestsVCに通知する
             if requests.count > oldValue.count {
-                let title = requests[requests.count - 1].title
-                NotificationCenter.default.post(name: .requestQueueToRequestsVCName, object: nil, userInfo: ["title": title])
-                // TODO: [amylase] RequestsViewControllerにsongIDを追加で渡す
+                let title  = requests[requests.count - 1].title
+                let songID = requests[requests.count - 1].songID
+                NotificationCenter.default.post(name: .requestQueueToRequestsVCName, object: nil, userInfo: ["title": title, "songID": songID])
             }
         }
     }

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -89,8 +89,8 @@ class RequestsViewController: UIViewController {
         }
     }
     @IBAction func skip(_ sender: Any) {
+        guard musicPlayerApplicationController.nowPlayingItem != nil else { return }
         musicPlayerApplicationController.skipToNextItem()
-        //FIXME: 再生キューに何もないと落ちる
     }
     
 }

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -65,36 +65,26 @@ class RequestsViewController: UIViewController {
         alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
 
         present(alert, animated: true)
-        
+    }    
+    func insertMusicPlayerControllerQueue(songID : String){
         // リクエストされた楽曲をキューに追加
         if (wasCreatedQueue){
             //2回目以降
-            insertMusicPlayerControllerQueue(songID: songID)
+            musicPlayerApplicationController.perform(queueTransaction: { mutableQueue in
+                let descripter = MPMusicPlayerStoreQueueDescriptor(storeIDs: [songID])
+                mutableQueue.insert(descripter, after: mutableQueue.items.last)
+            }, completionHandler: { queue, error in
+                if (error != nil){
+                    // TODO: キューへの追加ができなかった時の処理を記述
+                }
+            })
         }else{
             //初回呼び出し時
-            applyMusicPlayerControllerQueue(songID: songID)
+            let descripter = MPMusicPlayerStoreQueueDescriptor(storeIDs: [songID])
+            musicPlayerApplicationController.setQueue(with: descripter)
+            musicPlayerApplicationController.play()
             wasCreatedQueue = true
         }
-    }
-
-    func applyMusicPlayerControllerQueue(songID : String){
-        // AppleMusic内の楽曲のdescripterを作成　ローカルライブラリ内の楽曲には使えないので注意
-        let descripter = MPMusicPlayerStoreQueueDescriptor(storeIDs: [songID])
-        
-        musicPlayerApplicationController.setQueue(with: descripter)
-        musicPlayerApplicationController.play()
-    }
-    
-    func insertMusicPlayerControllerQueue(songID : String){
-        musicPlayerApplicationController.perform(queueTransaction: { mutableQueue in
-            // AppleMusic内の楽曲のdescripterを作成　ローカルライブラリ内の楽曲には使えないので注意
-            let descripter = MPMusicPlayerStoreQueueDescriptor(storeIDs: [songID])
-            mutableQueue.insert(descripter, after: mutableQueue.items.last)
-        }, completionHandler: { queue, error in
-            if (error != nil){
-                // TODO: キューへの追加ができなかった時の処理を記述
-            }
-        })
     }
 }
 

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -76,7 +76,10 @@ class RequestsViewController: UIViewController {
             wasCreatedQueue = true
         }
     }
-    
+}
+
+// MARK: - UIViewController
+extension RequestsViewController{
     // AppleMusic内の楽曲のdescripterを作成　ローカルライブラリ内の楽曲には使えないので注意
     func makePlayerStoreQueueDescriptor(songID: String) -> MPMusicPlayerStoreQueueDescriptor{
         let descripter = MPMusicPlayerStoreQueueDescriptor(storeIDs: [songID])

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -68,7 +68,7 @@ class RequestsViewController: UIViewController {
     
     func insertMusicPlayerControllerQueue(mediaItemCollection : MPMediaItemCollection){
         musicPlayerApplicationController.perform(queueTransaction: { mutableQueue in
-            let predicate = MPMediaPropertyPredicate(value: mediaItemCollection.representativeItem!.persistentID,
+            let predicate = MPMediaPropertyPredicate(value: mediaItemCollection.representativeItem!.persistentID, // persistentID = 
                                                      forProperty: MPMediaItemPropertyPersistentID)
             
             let query = MPMediaQuery(filterPredicates: [predicate])

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import StoreKit
+import MediaPlayer
 
 class RequestsViewController: UIViewController {
     @IBOutlet weak var tableView: UITableView!
@@ -17,6 +18,8 @@ class RequestsViewController: UIViewController {
     private let cloudServiceController = SKCloudServiceController()
     private let defaultArtwork : UIImage = UIImage()
     private var storefrontCountryCode : String? = nil
+    
+    private let musicPlayer : MPMusicPlayerController! = MPMusicPlayerController.systemMusicPlayer
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -30,6 +33,11 @@ class RequestsViewController: UIViewController {
             guard status == .authorized else { return }
             // TODO: Apple Musicの契約確認処理
         }
+        // Apple Musicの曲が再生可能か確認（Apple Musicの契約確認処理と同義？）
+        self.cloudServiceController.requestCapabilities { (capabilities, error) in
+            guard capabilities.contains(.musicCatalogPlayback) else { return }
+        }
+        
         
         let footerView = UIView()
         footerView.frame.size.height = tableView.rowHeight
@@ -43,6 +51,11 @@ class RequestsViewController: UIViewController {
     
     @objc func updateRequests(){
         tableView.reloadData()
+    }
+    
+    
+    func updateMusicPlayerControllerQueue(){
+        
     }
 }
 

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -90,6 +90,8 @@ class RequestsViewController: UIViewController {
         print("descripter: ", descripter)
         
         musicPlayerApplicationController.setQueue(with: descripter)
+        
+        self.musicPlayerApplicationController.play()
 //        musicPlayerApplicationController.nowPlayingItem() //必要かどうか微妙
     }
     

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -55,6 +55,7 @@ class RequestsViewController: UIViewController {
         DispatchQueue.main.async{
             self.tableView.reloadData()
         }
+        // TODO: [amylase] insertMusicPlayerControllerQueueを呼び出す
         // リクエストが完了した旨のAlertを表示
         guard let title = notification.userInfo!["title"] as? String else { return }
         
@@ -66,17 +67,24 @@ class RequestsViewController: UIViewController {
     }
     
     
-    func insertMusicPlayerControllerQueue(mediaItemCollection : MPMediaItemCollection){
+    func insertMusicPlayerControllerQueue(persistentID : UInt64){
         musicPlayerApplicationController.perform(queueTransaction: { mutableQueue in
-            let predicate = MPMediaPropertyPredicate(value: mediaItemCollection.representativeItem!.persistentID, // persistentID = 
+            let predicate = MPMediaPropertyPredicate(value: persistentID,
                                                      forProperty: MPMediaItemPropertyPersistentID)
             
             let query = MPMediaQuery(filterPredicates: [predicate])
             let descripter = MPMusicPlayerMediaItemQueueDescriptor(query: query)
             
             mutableQueue.insert(descripter, after: mutableQueue.items.last)
+            
+            //ボタンを追加するまで、queueに曲が追加されたら再生を始めるものとする
+            //エラーは考えない
+            if (self.musicPlayerApplicationController.playbackState != .playing){
+                self.musicPlayerApplicationController.play()
+            }
         }, completionHandler: { queue, error in
             if (error != nil){
+                print("insert error.")
                 // TODO: キューへの追加ができなかった時の処理を記述
             }
         })
@@ -118,6 +126,7 @@ extension RequestsViewController: UITableViewDelegate {
         if editingStyle == .delete {
             RequestQueue.shared.removeRequest(index: indexPath.row)
             tableView.deleteRows(at: [indexPath], with: .fade)
+            //TODO: playerのqueueの中も削除
         }
     }
 }

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -18,7 +18,6 @@ class RequestsViewController: UIViewController {
     private let cloudServiceController = SKCloudServiceController()
     private let defaultArtwork : UIImage = UIImage()
     private var storefrontCountryCode : String? = nil
-    private var mediaItems: [MPMediaItem] = []
     private var wasCreatedQueue = false
     
     private let musicPlayerApplicationController = MPMusicPlayerController.applicationQueuePlayer
@@ -56,15 +55,17 @@ class RequestsViewController: UIViewController {
         DispatchQueue.main.async{
             self.tableView.reloadData()
         }
-        guard let songID = notification.userInfo!["songID"] as? String else { return }
         // リクエストが完了した旨のAlertを表示
-        guard let title = notification.userInfo!["title"] as? String else { return }
+        guard let songID = notification.userInfo!["songID"] as? String,
+              let title  = notification.userInfo!["title"]  as? String else { return }
         
         let alert = UIAlertController(title: title, message: "was Requested", preferredStyle: UIAlertController.Style.alert)
 
         alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
 
         present(alert, animated: true)
+        
+        insertMusicPlayerControllerQueue(songID: songID)
     }    
     func insertMusicPlayerControllerQueue(songID : String){
         // リクエストされた楽曲をキューに追加

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -76,27 +76,20 @@ class RequestsViewController: UIViewController {
             wasCreatedQueue = true
         }
     }
-}
 
-// MARK: - UIViewController
-extension RequestsViewController{
-    // AppleMusic内の楽曲のdescripterを作成　ローカルライブラリ内の楽曲には使えないので注意
-    func makePlayerStoreQueueDescriptor(songID: String) -> MPMusicPlayerStoreQueueDescriptor{
-        let descripter = MPMusicPlayerStoreQueueDescriptor(storeIDs: [songID])
-        return descripter
-    }
-    
     func applyMusicPlayerControllerQueue(songID : String){
-        let descripter = makePlayerStoreQueueDescriptor(songID: songID)
+        // AppleMusic内の楽曲のdescripterを作成　ローカルライブラリ内の楽曲には使えないので注意
+        let descripter = MPMusicPlayerStoreQueueDescriptor(storeIDs: [songID])
+        
         musicPlayerApplicationController.setQueue(with: descripter)
         musicPlayerApplicationController.play()
     }
     
     func insertMusicPlayerControllerQueue(songID : String){
         musicPlayerApplicationController.perform(queueTransaction: { mutableQueue in
-            let descripter = self.makePlayerStoreQueueDescriptor(songID: songID)
+            // AppleMusic内の楽曲のdescripterを作成　ローカルライブラリ内の楽曲には使えないので注意
+            let descripter = MPMusicPlayerStoreQueueDescriptor(storeIDs: [songID])
             mutableQueue.insert(descripter, after: mutableQueue.items.last)
-            print("mutableQueue.items.count:", mutableQueue.items.count)
         }, completionHandler: { queue, error in
             if (error != nil){
                 // TODO: キューへの追加ができなかった時の処理を記述

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -14,6 +14,7 @@ class RequestsViewController: UIViewController {
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var playingArtwork: UIImageView!
     @IBOutlet weak var playingTitle: UILabel!
+    @IBOutlet weak var skipButton: UIButton!
     
     private let cloudServiceController = SKCloudServiceController()
     private let defaultArtwork : UIImage = UIImage()
@@ -76,6 +77,11 @@ class RequestsViewController: UIViewController {
             wasCreatedQueue = true
         }
     }
+    @IBAction func skip(_ sender: Any) {
+        musicPlayerApplicationController.skipToNextItem()
+        //FIXME: 再生キューに何もないと落ちる
+    }
+    
 }
 
 // MARK: - UIViewController
@@ -96,7 +102,6 @@ extension RequestsViewController{
         musicPlayerApplicationController.perform(queueTransaction: { mutableQueue in
             let descripter = self.makePlayerStoreQueueDescriptor(songID: songID)
             mutableQueue.insert(descripter, after: mutableQueue.items.last)
-            print("mutableQueue.items.count:", mutableQueue.items.count)
         }, completionHandler: { queue, error in
             if (error != nil){
                 // TODO: キューへの追加ができなかった時の処理を記述

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -57,14 +57,6 @@ class RequestsViewController: UIViewController {
             self.tableView.reloadData()
         }
         guard let songID = notification.userInfo!["songID"] as? String else { return }
-        if (wasCreatedQueue){
-            //2回目以降
-            insertMusicPlayerControllerQueue(songID: songID)
-        }else{
-            //初回呼び出し時
-            applyMusicPlayerControllerQueue(songID: songID)
-        }
-
         // リクエストが完了した旨のAlertを表示
         guard let title = notification.userInfo!["title"] as? String else { return }
         
@@ -73,6 +65,16 @@ class RequestsViewController: UIViewController {
         alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
 
         present(alert, animated: true)
+        
+        // リクエストされた楽曲をキューに追加
+        if (wasCreatedQueue){
+            //2回目以降
+            insertMusicPlayerControllerQueue(songID: songID)
+        }else{
+            //初回呼び出し時
+            applyMusicPlayerControllerQueue(songID: songID)
+            wasCreatedQueue = true
+        }
     }
     
     // AppleMusic内の楽曲のdescripterを作成　ローカルライブラリ内の楽曲には使えないので注意
@@ -83,20 +85,15 @@ class RequestsViewController: UIViewController {
     
     func applyMusicPlayerControllerQueue(songID : String){
         let descripter = makePlayerStoreQueueDescriptor(songID: songID)
-        
-        
         musicPlayerApplicationController.setQueue(with: descripter)
         musicPlayerApplicationController.play()
-        
     }
     
     func insertMusicPlayerControllerQueue(songID : String){
         musicPlayerApplicationController.perform(queueTransaction: { mutableQueue in
-        let descripter = self.makePlayerStoreQueueDescriptor(songID: songID)
-        mutableQueue.insert(descripter, after: mutableQueue.items.last)
-        print("mutableQueue.items.count:", mutableQueue.items.count)
-        
-
+            let descripter = self.makePlayerStoreQueueDescriptor(songID: songID)
+            mutableQueue.insert(descripter, after: mutableQueue.items.last)
+            print("mutableQueue.items.count:", mutableQueue.items.count)
         }, completionHandler: { queue, error in
             if (error != nil){
                 // TODO: キューへの追加ができなかった時の処理を記述

--- a/DJYusaku/SearchMusicTableViewCell.swift
+++ b/DJYusaku/SearchMusicTableViewCell.swift
@@ -18,6 +18,8 @@ class SearchMusicTableViewCell: UITableViewCell {
     //sendRequestに必要なURL型の変数(プライベート変数にするかも)
     var artworkUrl: URL?
     
+    var songID : UInt64!
+    
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code
@@ -38,6 +40,6 @@ class SearchMusicTableViewCell: UITableViewCell {
         button.isEnabled = false
         //artworkUrlがnilなら追加されない
         guard let artworkUrl = artworkUrl else { return }
-        RequestQueue.shared.addRequest(request: MusicDataModel(title: title.text ?? "", artist: artist.text ?? "", artworkUrl: artworkUrl))
+        RequestQueue.shared.addRequest(request: MusicDataModel(title: title.text ?? "", artist: artist.text ?? "", artworkUrl: artworkUrl, songID: songID))
     }
 }

--- a/DJYusaku/SearchMusicTableViewCell.swift
+++ b/DJYusaku/SearchMusicTableViewCell.swift
@@ -18,7 +18,7 @@ class SearchMusicTableViewCell: UITableViewCell {
     //sendRequestに必要なURL型の変数(プライベート変数にするかも)
     var artworkUrl: URL?
     
-    var songID : UInt64!
+    var songID : String!
     
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -68,6 +68,7 @@ extension SearchViewController: UITableViewDataSource {
         cell.title.text       = item.title
         cell.artist.text      = item.artist
         cell.artworkUrl       = item.artworkUrl
+        cell.songID           = item.songID
         cell.artwork.image    = defaultArtwork
         cell.button.isEnabled = true
         

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -154,8 +154,9 @@ extension SearchViewController: UISearchResultsUpdating {
                     let title            = song["attributes"]["name"].stringValue
                     let artist           = song["attributes"]["artistName"].stringValue
                     let artworkUrlString = song["attributes"]["artwork"]["url"].stringValue
+                    let songID           = song["attributes"]["playParams"]["id"].uInt64Value
                     let artworkUrl = Artwork.url(urlString: artworkUrlString, width: 256, height: 256)
-                    self.results.append(MusicDataModel(title: title, artist: artist, artworkUrl: artworkUrl))
+                    self.results.append(MusicDataModel(title: title, artist: artist, artworkUrl: artworkUrl, songID: songID))
                 }
                 self.tableView.reloadData()
             }

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -155,7 +155,7 @@ extension SearchViewController: UISearchResultsUpdating {
                     let title            = song["attributes"]["name"].stringValue
                     let artist           = song["attributes"]["artistName"].stringValue
                     let artworkUrlString = song["attributes"]["artwork"]["url"].stringValue
-                    let songID           = song["attributes"]["playParams"]["id"].uInt64Value
+                    let songID           = song["attributes"]["playParams"]["id"].stringValue
                     let artworkUrl = Artwork.url(urlString: artworkUrlString, width: 256, height: 256)
                     self.results.append(MusicDataModel(title: title, artist: artist, artworkUrl: artworkUrl, songID: songID))
                 }


### PR DESCRIPTION
## 概要
- 検索ボタンで曲を選択する（+ボタンを押す）と再生キューに楽曲が追加される
- 再生キューに楽曲が最初に追加される時、自動で再生
    - 再生・停止の各ボタンが追加されるまでの暫定処理
    

## 追加・変更点
- 楽曲IDの取得の追加
    - 検索結果に楽曲IDを保存するように変更
    - MusicDataModelに楽曲IDが登録できるように変更
    - #12 で追加されたnotificationに、一緒に楽曲IDも送信するように変更

- func makePlayerStoreQueueDescriptor(songID: String) -> MPMusicPlayerStoreQueueDescriptor
    - 楽曲のIDからAppleMusic内の楽曲のdescripterを作成

- func applyMusicPlayerControllerQueue(songID : String)
    - 楽曲のIDからdescripterを作り、playerのqueueに追加
    - 起動後初めて楽曲が追加される時のみ呼び出される

- func insertMusicPlayerControllerQueue(songID : String)
    - 楽曲のIDからdescripterを作り、playerのqueueの最後尾に追加
    - 2回目以降の追加で呼び出される


## @amylaseF85 が実機で確認したこと
- はじめて検索画面から楽曲を選択した時、自動で再生されることを確認
    - applyMusicPlayerControllerQueueの確認
- すでに楽曲Aが再生中（＝再生キューに楽曲がある）に楽曲Bを追加した時、Aが終了後にBが再生されることを確認
- すでに楽曲Aが再生中に楽曲B,Cを2つ追加した時、Aの次にBが再生されることを確認
    - insertMusicPlayerControllerQueueの確認

## 問題
- セルを表示するためのMusicDataModelを入れたキューと、playerのキューがそれぞれ存在する

## 今後
- Request画面の下のセルに再生中の楽曲の情報を出す