### PR TITLE
MUltipeerConnectivityでデバイス間接続を可能にする

### DIFF
--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1006887E236D3AC9004CAD5B /* MCConnecter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1006887D236D3AC9004CAD5B /* MCConnecter.swift */; };
 		10068882236D3F1F004CAD5B /* ListenerConnecterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10068881236D3F1F004CAD5B /* ListenerConnecterViewController.swift */; };
 		10068886236D5A60004CAD5B /* ConnectableDJsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10068885236D5A60004CAD5B /* ConnectableDJsTableViewCell.swift */; };
+		10068888236D7393004CAD5B /* MCConnecterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10068887236D7393004CAD5B /* MCConnecterDelegate.swift */; };
 		411F288B23616EEB00BA96C1 /* RequestQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411F288A23616EEB00BA96C1 /* RequestQueue.swift */; };
 		B125D88D235F426C00D383E7 /* Artwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = B125D88C235F426C00D383E7 /* Artwork.swift */; };
 		C40DC880236570DD00E80AB1 /* WelcomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40DC87F236570DD00E80AB1 /* WelcomeViewController.swift */; };
@@ -51,6 +52,7 @@
 		1006887D236D3AC9004CAD5B /* MCConnecter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCConnecter.swift; sourceTree = "<group>"; };
 		10068881236D3F1F004CAD5B /* ListenerConnecterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListenerConnecterViewController.swift; sourceTree = "<group>"; };
 		10068885236D5A60004CAD5B /* ConnectableDJsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectableDJsTableViewCell.swift; sourceTree = "<group>"; };
+		10068887236D7393004CAD5B /* MCConnecterDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCConnecterDelegate.swift; sourceTree = "<group>"; };
 		411F288A23616EEB00BA96C1 /* RequestQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestQueue.swift; sourceTree = "<group>"; };
 		B125D88C235F426C00D383E7 /* Artwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artwork.swift; sourceTree = "<group>"; };
 		C40DC87F236570DD00E80AB1 /* WelcomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeViewController.swift; sourceTree = "<group>"; };
@@ -142,6 +144,7 @@
 				411F288A23616EEB00BA96C1 /* RequestQueue.swift */,
 				C40DC87F236570DD00E80AB1 /* WelcomeViewController.swift */,
 				1006887D236D3AC9004CAD5B /* MCConnecter.swift */,
+				10068887236D7393004CAD5B /* MCConnecterDelegate.swift */,
 				10068881236D3F1F004CAD5B /* ListenerConnecterViewController.swift */,
 				10068885236D5A60004CAD5B /* ConnectableDJsTableViewCell.swift */,
 			);
@@ -303,6 +306,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				10068888236D7393004CAD5B /* MCConnecterDelegate.swift in Sources */,
 				B125D88D235F426C00D383E7 /* Artwork.swift in Sources */,
 				C4CF9725235163EF00C8A102 /* SearchViewController.swift in Sources */,
 				411F288B23616EEB00BA96C1 /* RequestQueue.swift in Sources */,

--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1006887E236D3AC9004CAD5B /* MCConnecter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1006887D236D3AC9004CAD5B /* MCConnecter.swift */; };
+		10068882236D3F1F004CAD5B /* ListenerConnecterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10068881236D3F1F004CAD5B /* ListenerConnecterViewController.swift */; };
+		10068886236D5A60004CAD5B /* ConnectableDJsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10068885236D5A60004CAD5B /* ConnectableDJsTableViewCell.swift */; };
 		411F288B23616EEB00BA96C1 /* RequestQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411F288A23616EEB00BA96C1 /* RequestQueue.swift */; };
 		B125D88D235F426C00D383E7 /* Artwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = B125D88C235F426C00D383E7 /* Artwork.swift */; };
 		C40DC880236570DD00E80AB1 /* WelcomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40DC87F236570DD00E80AB1 /* WelcomeViewController.swift */; };
@@ -45,6 +48,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1006887D236D3AC9004CAD5B /* MCConnecter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCConnecter.swift; sourceTree = "<group>"; };
+		10068881236D3F1F004CAD5B /* ListenerConnecterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListenerConnecterViewController.swift; sourceTree = "<group>"; };
+		10068885236D5A60004CAD5B /* ConnectableDJsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectableDJsTableViewCell.swift; sourceTree = "<group>"; };
 		411F288A23616EEB00BA96C1 /* RequestQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestQueue.swift; sourceTree = "<group>"; };
 		B125D88C235F426C00D383E7 /* Artwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artwork.swift; sourceTree = "<group>"; };
 		C40DC87F236570DD00E80AB1 /* WelcomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeViewController.swift; sourceTree = "<group>"; };
@@ -135,6 +141,9 @@
 				B125D88C235F426C00D383E7 /* Artwork.swift */,
 				411F288A23616EEB00BA96C1 /* RequestQueue.swift */,
 				C40DC87F236570DD00E80AB1 /* WelcomeViewController.swift */,
+				1006887D236D3AC9004CAD5B /* MCConnecter.swift */,
+				10068881236D3F1F004CAD5B /* ListenerConnecterViewController.swift */,
+				10068885236D5A60004CAD5B /* ConnectableDJsTableViewCell.swift */,
 			);
 			path = DJYusaku;
 			sourceTree = "<group>";
@@ -298,14 +307,17 @@
 				C4CF9725235163EF00C8A102 /* SearchViewController.swift in Sources */,
 				411F288B23616EEB00BA96C1 /* RequestQueue.swift in Sources */,
 				C4FDD0CC2356EA8F007569B1 /* RequestsMusicTableViewCell.swift in Sources */,
+				1006887E236D3AC9004CAD5B /* MCConnecter.swift in Sources */,
 				C436A8562350B16B009F6498 /* MusicDataModel.swift in Sources */,
 				C4D25958235205D10066FCE0 /* Secrets.swift in Sources */,
+				10068886236D5A60004CAD5B /* ConnectableDJsTableViewCell.swift in Sources */,
 				C447ACAA234882F900D535EB /* RequestsViewController.swift in Sources */,
 				C447ACA6234882F900D535EB /* AppDelegate.swift in Sources */,
 				C4D2595A235205EC0066FCE0 /* Secrets+Local.swift in Sources */,
 				C40DC880236570DD00E80AB1 /* WelcomeViewController.swift in Sources */,
 				C447ACA8234882F900D535EB /* SceneDelegate.swift in Sources */,
 				C436A8582350D36F009F6498 /* SearchMusicTableViewCell.swift in Sources */,
+				10068882236D3F1F004CAD5B /* ListenerConnecterViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -481,13 +493,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = J87XZSWPMZ;
+				DEVELOPMENT_TEAM = SZ55PXK5GR;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.amylase;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.tsuu32;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -500,13 +512,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = J87XZSWPMZ;
+				DEVELOPMENT_TEAM = SZ55PXK5GR;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.amylase;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.tsuu32;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -259,7 +259,6 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                                 <connections>
-                                    <action selector="joinAsListener:" destination="ypK-t8-Qz5" eventType="touchUpInside" id="0Y6-WE-bx6"/>
                                     <segue destination="OLS-yY-NwI" kind="show" id="OT6-D8-sjH"/>
                                 </connections>
                             </button>

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15508"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -239,7 +239,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                                 <connections>
-                                    <segue destination="np9-K9-Npw" kind="show" id="03f-GL-4oG"/>
+                                    <action selector="joinAsDJ:" destination="ypK-t8-Qz5" eventType="touchUpInside" id="Lkl-fy-H0Z"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RGD-qI-6Bt">
@@ -333,25 +333,54 @@
         <!--Join as a listener-->
         <scene sceneID="z8Z-ZC-zfs">
             <objects>
-                <viewController id="2ZU-rh-NCc" sceneMemberID="viewController">
+                <viewController id="2ZU-rh-NCc" customClass="ListenerConnecterViewController" customModule="DJYusaku" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="TEh-b3-bIb">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="758"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="G0K-wU-9UD">
+                                <rect key="frame" x="67" y="160" width="240" height="410"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="c2n-n3-QEE">
+                                        <rect key="frame" x="0.0" y="28" width="240" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="c2n-n3-QEE" id="h9R-t6-nb1">
+                                            <rect key="frame" x="0.0" y="0.0" width="240" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YrH-B5-bF3">
+                                                    <rect key="frame" x="15" y="11" width="210" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                        </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="Kt9-XD-t6e"/>
                     </view>
                     <navigationItem key="navigationItem" title="Join as a listener" id="dzb-SC-M7Y"/>
+                    <connections>
+                        <outlet property="tableView" destination="G0K-wU-9UD" id="6Sd-tz-0RV"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x2a-pV-KQr" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4739" y="-321"/>
+            <point key="canvasLocation" x="4738.3999999999996" y="-321.42857142857144"/>
         </scene>
         <!--Join as the DJ-->
         <scene sceneID="utz-Cr-c0P">
             <objects>
-                <viewController id="np9-K9-Npw" sceneMemberID="viewController">
+                <viewController id="np9-K9-Npw" customClass="DJConnecterViewController" customModule="DJYusaku" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="1eA-j5-7PN">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="758"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="llR-Fx-3vG"/>

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -259,7 +259,8 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                                 <connections>
-                                    <segue destination="2ZU-rh-NCc" kind="show" id="C38-vy-ezJ"/>
+                                    <action selector="joinAsListener:" destination="ypK-t8-Qz5" eventType="touchUpInside" id="0Y6-WE-bx6"/>
+                                    <segue destination="OLS-yY-NwI" kind="show" id="OT6-D8-sjH"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="requires Apple Music contract" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QLv-BI-r7q">
@@ -330,28 +331,28 @@
             </objects>
             <point key="canvasLocation" x="3662" y="-677"/>
         </scene>
-        <!--Join as a listener-->
-        <scene sceneID="z8Z-ZC-zfs">
+        <!--Listener Connecter View Controller-->
+        <scene sceneID="vuj-ym-VGP">
             <objects>
-                <viewController id="2ZU-rh-NCc" customClass="ListenerConnecterViewController" customModule="DJYusaku" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="TEh-b3-bIb">
+                <viewController id="OLS-yY-NwI" customClass="ListenerConnecterViewController" customModule="DJYusaku" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="pqb-b1-ZR8">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="758"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="G0K-wU-9UD">
-                                <rect key="frame" x="67" y="160" width="240" height="410"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="35h-V4-ThQ">
+                                <rect key="frame" x="0.0" y="44" width="375" height="680"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="c2n-n3-QEE">
-                                        <rect key="frame" x="0.0" y="28" width="240" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="ConnectableDJsTableViewCell" id="wx8-AK-cV7" customClass="ConnectableDJsTableViewCell" customModule="DJYusaku" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="c2n-n3-QEE" id="h9R-t6-nb1">
-                                            <rect key="frame" x="0.0" y="0.0" width="240" height="44"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="wx8-AK-cV7" id="q36-v5-swO" customClass="ConnectableDJsTableViewCell" customModule="DJYusaku" customModuleProvider="target">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YrH-B5-bF3">
-                                                    <rect key="frame" x="15" y="11" width="210" height="21"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dtx-az-HKZ">
+                                                    <rect key="frame" x="15" y="11" width="342" height="22"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -359,37 +360,24 @@
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="djName" destination="dtx-az-HKZ" id="Z1w-Xw-ji3"/>
+                                        </connections>
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                        <viewLayoutGuide key="safeArea" id="Kt9-XD-t6e"/>
+                        <viewLayoutGuide key="safeArea" id="yWV-eC-iU0"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Join as a listener" id="dzb-SC-M7Y"/>
+                    <navigationItem key="navigationItem" id="jWx-fE-3TV"/>
                     <connections>
-                        <outlet property="tableView" destination="G0K-wU-9UD" id="6Sd-tz-0RV"/>
+                        <outlet property="tableView" destination="35h-V4-ThQ" id="CsF-DS-X6F"/>
                     </connections>
                 </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="x2a-pV-KQr" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="0Ep-2e-wnc" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4738.3999999999996" y="-321.42857142857144"/>
-        </scene>
-        <!--Join as the DJ-->
-        <scene sceneID="utz-Cr-c0P">
-            <objects>
-                <viewController id="np9-K9-Npw" customClass="DJConnecterViewController" customModule="DJYusaku" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="1eA-j5-7PN">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                        <viewLayoutGuide key="safeArea" id="llR-Fx-3vG"/>
-                    </view>
-                    <navigationItem key="navigationItem" title="Join as the DJ" id="91p-ae-J31"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="tEG-tD-Wkz" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="4738" y="-1034"/>
+            <point key="canvasLocation" x="4645.6000000000004" y="-676.10837438423653"/>
         </scene>
         <!--Search-->
         <scene sceneID="wg7-f3-ORb">

--- a/DJYusaku/ConnectableDJsTableViewCell.swift
+++ b/DJYusaku/ConnectableDJsTableViewCell.swift
@@ -8,5 +8,5 @@
 
 import UIKit
 class ConnectableDJsTableViewCell: UITableViewCell {
-    
+    @IBOutlet weak var djName: UILabel!
 }

--- a/DJYusaku/ConnectableDJsTableViewCell.swift
+++ b/DJYusaku/ConnectableDJsTableViewCell.swift
@@ -1,0 +1,12 @@
+//
+//  ConnectableDJsTableViewCell.swift
+//  DJYusaku
+//
+//  Created by Masahiro Nakamura on 2019/11/02.
+//  Copyright © 2019 Yusaku. All rights reserved.
+//
+
+import UIKit
+class ConnectableDJsTableViewCell: UITableViewCell {
+    
+}

--- a/DJYusaku/ListenerConnecterViewController.swift
+++ b/DJYusaku/ListenerConnecterViewController.swift
@@ -57,7 +57,9 @@ extension ListenerConnecterViewController: UITableViewDataSource {
     }
     
      func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        MCConnecter.shared.browser.invitePeer(MCConnecter.shared.connectableDJs[indexPath.row], to: MCConnecter.shared.session, withContext: nil, timeout: 10.0)
+        let selectedDJ = MCConnecter.shared.connectableDJs[indexPath.row]
+        MCConnecter.shared.browser.invitePeer(selectedDJ, to: MCConnecter.shared.session, withContext: nil, timeout: 10.0)
+        MCConnecter.shared.connectedDJ = selectedDJ
         MCConnecter.shared.stopBrowse()
         self.dismiss(animated: true, completion: nil)
     }

--- a/DJYusaku/ListenerConnecterViewController.swift
+++ b/DJYusaku/ListenerConnecterViewController.swift
@@ -78,7 +78,7 @@ extension ListenerConnecterViewController: MCConnecterDelegate {
     }
 
     func mcConnecter(connectableDevicesChanged devices: [MCPeerID]) {
-        print("changed")
+        // browserがピアを見つけたらリロード
         self.tableView.reloadData()
     }
 }

--- a/DJYusaku/ListenerConnecterViewController.swift
+++ b/DJYusaku/ListenerConnecterViewController.swift
@@ -7,28 +7,40 @@
 //
 
 import UIKit
+import MultipeerConnectivity
 
 class ListenerConnecterViewController: UIViewController {
-    
+        
     @IBOutlet weak var tableView: UITableView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        if (MCConnecter.shared.session != nil) { }
+        if (MCConnecter.shared.session != nil) {
+            print("aaaa")
+        }
         else {
-        MCConnecter.shared.initialize(isParent: false, displayName: UIDevice.current.name)
+            MCConnecter.shared.initialize(isParent: false, displayName: UIDevice.current.name)
+            MCConnecter.shared.startBrowse()
+            print("bbbbb")
         }
         
-        MCConnecter.shared.startBrowse()
         // tableViewのdelegate, dataSource設定
         tableView.delegate = self
         tableView.dataSource = self
         
         print("connectableDJs: ",MCConnecter.shared.connectableDJs)
+        
+        // NotificationCenter.default.addObserver(self, selector: #selector(handleDJUpdated), name: .welcomeVCToListenerConnecterVCName, object: nil)
     }
     
-    
+//    @objc func handleDJUpdated () {
+//        // リクエスト画面を更新
+//        DispatchQueue.main.async{
+//            self.tableView.reloadData()
+//        }
+//        print("update")
+//    }
 
     /*
     // MARK: - Navigation
@@ -46,15 +58,21 @@ class ListenerConnecterViewController: UIViewController {
 
 extension ListenerConnecterViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        print("vcccccc")
         return MCConnecter.shared.connectableDJs.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "ConnectableDJsTableViewCell", for: indexPath) as! SearchMusicTableViewCell
-        
+        let cell = tableView.dequeueReusableCell(withIdentifier: "ConnectableDJsTableViewCell", for: indexPath) as! ConnectableDJsTableViewCell
         let item = MCConnecter.shared.connectableDJs[indexPath.row]
-        cell.title.text       = item.displayName
-        cell.button.isEnabled = true
+        cell.djName?.text = "DJ: " + item.displayName
+        print("DJ: " + item.displayName)
+        
+        // リクエスト画面を更新
+//        DispatchQueue.main.async {
+//            self.tableView.reloadData()
+//        }
+
         return cell
     }
 }
@@ -63,4 +81,21 @@ extension ListenerConnecterViewController: UITableViewDataSource {
 
 extension ListenerConnecterViewController: UITableViewDelegate {
     /* TODO: 未実装 */
+}
+
+// MARK: - MCConnecterDelegate
+extension ListenerConnecterViewController: MCConnecterDelegate {
+    func mcConnecter(didReceiveData data: Data, ofType type: UInt32) {
+        
+    }
+    
+    func mcConnecter(connectedDevicesChanged devices: [String]) {
+        
+    }
+    
+
+    func mcConnecter(connectableDevicesChanged devices: [MCPeerID], browser: MCNearbyServiceBrowser) {
+        print(devices)
+        self.tableView.reloadData()
+    }
 }

--- a/DJYusaku/ListenerConnecterViewController.swift
+++ b/DJYusaku/ListenerConnecterViewController.swift
@@ -55,6 +55,12 @@ extension ListenerConnecterViewController: UITableViewDataSource {
 
         return cell
     }
+    
+     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        MCConnecter.shared.browser.invitePeer(MCConnecter.shared.connectableDJs[indexPath.row], to: MCConnecter.shared.session, withContext: nil, timeout: 10.0)
+        MCConnecter.shared.stopBrowse()
+        self.dismiss(animated: true, completion: nil)
+    }
 }
 
 // MARK: - UITableViewDelegate
@@ -65,11 +71,7 @@ extension ListenerConnecterViewController: UITableViewDelegate {
 
 // MARK: - MCConnecterDelegate
 extension ListenerConnecterViewController: MCConnecterDelegate {
-    func mcConnecter(didReceiveData data: Data, ofType type: UInt32) {
-        
-    }
-    
-    func mcConnecter(connectedDevicesChanged devices: [String]) {
+    func mcConnecter(didReceiveData data: Data, from peerID: MCPeerID) {
         
     }
 

--- a/DJYusaku/ListenerConnecterViewController.swift
+++ b/DJYusaku/ListenerConnecterViewController.swift
@@ -1,0 +1,66 @@
+//
+//  ListenerConnecterViewController.swift
+//  DJYusaku
+//
+//  Created by Masahiro Nakamura on 2019/11/02.
+//  Copyright © 2019 Yusaku. All rights reserved.
+//
+
+import UIKit
+
+class ListenerConnecterViewController: UIViewController {
+    
+    @IBOutlet weak var tableView: UITableView!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        if (MCConnecter.shared.session != nil) { }
+        else {
+        MCConnecter.shared.initialize(isParent: false, displayName: UIDevice.current.name)
+        }
+        
+        MCConnecter.shared.startBrowse()
+        // tableViewのdelegate, dataSource設定
+        tableView.delegate = self
+        tableView.dataSource = self
+        
+        print("connectableDJs: ",MCConnecter.shared.connectableDJs)
+    }
+    
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}
+
+// MARK: - UITableViewDataSource
+
+extension ListenerConnecterViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return MCConnecter.shared.connectableDJs.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "ConnectableDJsTableViewCell", for: indexPath) as! SearchMusicTableViewCell
+        
+        let item = MCConnecter.shared.connectableDJs[indexPath.row]
+        cell.title.text       = item.displayName
+        cell.button.isEnabled = true
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate
+
+extension ListenerConnecterViewController: UITableViewDelegate {
+    /* TODO: 未実装 */
+}

--- a/DJYusaku/ListenerConnecterViewController.swift
+++ b/DJYusaku/ListenerConnecterViewController.swift
@@ -16,31 +16,17 @@ class ListenerConnecterViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        if (MCConnecter.shared.session != nil) {
-            print("aaaa")
-        }
-        else {
+        if (!MCConnecter.shared.initialized) {
             MCConnecter.shared.initialize(isParent: false, displayName: UIDevice.current.name)
-            MCConnecter.shared.startBrowse()
-            print("bbbbb")
         }
+        MCConnecter.shared.delegate = self
+        MCConnecter.shared.startBrowse()
         
         // tableViewのdelegate, dataSource設定
         tableView.delegate = self
         tableView.dataSource = self
         
-        print("connectableDJs: ",MCConnecter.shared.connectableDJs)
-        
-        // NotificationCenter.default.addObserver(self, selector: #selector(handleDJUpdated), name: .welcomeVCToListenerConnecterVCName, object: nil)
     }
-    
-//    @objc func handleDJUpdated () {
-//        // リクエスト画面を更新
-//        DispatchQueue.main.async{
-//            self.tableView.reloadData()
-//        }
-//        print("update")
-//    }
 
     /*
     // MARK: - Navigation
@@ -58,7 +44,6 @@ class ListenerConnecterViewController: UIViewController {
 
 extension ListenerConnecterViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        print("vcccccc")
         return MCConnecter.shared.connectableDJs.count
     }
     
@@ -66,12 +51,7 @@ extension ListenerConnecterViewController: UITableViewDataSource {
         let cell = tableView.dequeueReusableCell(withIdentifier: "ConnectableDJsTableViewCell", for: indexPath) as! ConnectableDJsTableViewCell
         let item = MCConnecter.shared.connectableDJs[indexPath.row]
         cell.djName?.text = "DJ: " + item.displayName
-        print("DJ: " + item.displayName)
-        
-        // リクエスト画面を更新
-//        DispatchQueue.main.async {
-//            self.tableView.reloadData()
-//        }
+        print("DJ: [" + item.displayName + "]")
 
         return cell
     }
@@ -92,10 +72,9 @@ extension ListenerConnecterViewController: MCConnecterDelegate {
     func mcConnecter(connectedDevicesChanged devices: [String]) {
         
     }
-    
 
-    func mcConnecter(connectableDevicesChanged devices: [MCPeerID], browser: MCNearbyServiceBrowser) {
-        print(devices)
+    func mcConnecter(connectableDevicesChanged devices: [MCPeerID]) {
+        print("changed")
         self.tableView.reloadData()
     }
 }

--- a/DJYusaku/MCConnecter.swift
+++ b/DJYusaku/MCConnecter.swift
@@ -53,18 +53,26 @@ class MCConnecter: NSObject {
         browser.startBrowsingForPeers()
     }
     
+    func stopBrowse() {
+        browser.stopBrowsingForPeers()
+    }
+    
 }
 
 // MARK: - MCSessionDelegate
 extension MCConnecter: MCSessionDelegate {
     // 接続ピアの状態が変化したとき呼ばれる
     func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
-        print(#function)
+        if state == .connected {
+            print("Peer \(peerID.displayName) is connected.")
+        } else {
+            print("Peer \(peerID.displayName) is not connected.")
+        }
     }
     
     // 他のピアによる send を受け取ったとき呼ばれる
     func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
-        print(#function)
+        print("recieved Data: \(String(data: data, encoding: .utf8)!)")
         DispatchQueue.main.async {
             self.delegate?.mcConnecter(didReceiveData: data, from: peerID)
         }
@@ -104,7 +112,7 @@ extension MCConnecter: MCNearbyServiceBrowserDelegate {
     public func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String: String]?) {
         self.connectableDJs.append(peerID)
             
-        print("browser: found")
+        print("browser: connectable  DJ is found")
             
         DispatchQueue.main.async {
             self.delegate?.mcConnecter(connectableDevicesChanged: self.connectableDJs)
@@ -113,6 +121,8 @@ extension MCConnecter: MCNearbyServiceBrowserDelegate {
 
     // 接続可能なピアが消えたとき
     public func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
+        print("browser: connectable  DJ is lost")
+        
         connectableDJs = connectableDJs.filter { $0 != peerID }
         
         DispatchQueue.main.async {

--- a/DJYusaku/MCConnecter.swift
+++ b/DJYusaku/MCConnecter.swift
@@ -22,7 +22,9 @@ class MCConnecter: NSObject {
     var browser: MCNearbyServiceBrowser!
 
     var initialized = false
+    
     var connectableDJs: [MCPeerID] = []
+    var connectedDJ: MCPeerID!
     
     var isParent: Bool!
     

--- a/DJYusaku/MCConnecter.swift
+++ b/DJYusaku/MCConnecter.swift
@@ -21,12 +21,13 @@ class MCConnecter: NSObject {
     var advertiser: MCNearbyServiceAdvertiser!
     var browser: MCNearbyServiceBrowser!
 
-    
+    var initialized = false
     var connectableDJs: [MCPeerID] = []
     
     var isParent: Bool!
     
     func initialize(isParent: Bool, displayName: String) {
+        self.initialized = true
         self.isParent = isParent
         
         self.peerID = MCPeerID(displayName: displayName)
@@ -64,6 +65,9 @@ extension MCConnecter: MCSessionDelegate {
     // 他のピアによる send を受け取ったとき呼ばれる
     func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
         print(#function)
+        DispatchQueue.main.async {
+            self.delegate?.mcConnecter(didReceiveData: data, from: peerID)
+        }
     }
     
     // 他のピアによる sendStream を受け取ったとき呼ばれる
@@ -98,15 +102,12 @@ extension MCConnecter: MCNearbyServiceBrowserDelegate {
 
     // 接続可能なピアが見つかったとき
     public func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String: String]?) {
-        DispatchQueue.global().async {
-            self.connectableDJs.append(peerID)
+        self.connectableDJs.append(peerID)
             
-            print("browser found")
+        print("browser: found")
             
-            DispatchQueue.main.async {
-                print("async")
-                self.delegate?.mcConnecter(connectableDevicesChanged: self.connectableDJs, browser: browser)
-            }
+        DispatchQueue.main.async {
+            self.delegate?.mcConnecter(connectableDevicesChanged: self.connectableDJs)
         }
     }
 
@@ -115,7 +116,7 @@ extension MCConnecter: MCNearbyServiceBrowserDelegate {
         connectableDJs = connectableDJs.filter { $0 != peerID }
         
         DispatchQueue.main.async {
-                self.delegate?.mcConnecter(connectableDevicesChanged: self.connectableDJs, browser: browser)
+                self.delegate?.mcConnecter(connectableDevicesChanged: self.connectableDJs)
         }
     }
 

--- a/DJYusaku/MCConnecter.swift
+++ b/DJYusaku/MCConnecter.swift
@@ -1,0 +1,110 @@
+//
+//  MCConnecter.swift
+//  DJYusaku
+//
+//  Created by Masahiro Nakamura on 2019/11/02.
+//  Copyright © 2019 Yusaku. All rights reserved.
+//
+
+import Foundation
+import MultipeerConnectivity
+
+class MCConnecter: NSObject {
+    static let shared = MCConnecter()
+    
+    let serviceType = "djyusaku"
+    
+    var peerID :MCPeerID!
+    var session: MCSession!
+    var advertiser: MCNearbyServiceAdvertiser!
+    var browser: MCNearbyServiceBrowser!
+    
+    var connectableDJs: [MCPeerID] = []
+    
+    var isParent: Bool!
+    
+    func initialize(isParent: Bool, displayName: String) {
+        self.isParent = isParent
+        
+        self.peerID = MCPeerID(displayName: displayName)
+        self.session = MCSession(peer: self.peerID)
+        session.delegate = self
+        
+        advertiser = MCNearbyServiceAdvertiser(peer: self.peerID, discoveryInfo: nil, serviceType: self.serviceType)
+        advertiser.delegate = self
+
+        browser = MCNearbyServiceBrowser(peer: self.peerID, serviceType: self.serviceType)
+        browser.delegate = self
+    }
+    
+    func parent() -> Bool {
+        return self.isParent
+    }
+    
+    func startAdvertise() {
+        advertiser.startAdvertisingPeer()
+    }
+    
+    func startBrowse() {
+        browser.startBrowsingForPeers()
+    }
+    
+}
+
+// MARK: - MCSessionDelegate
+extension MCConnecter: MCSessionDelegate {
+    // 接続ピアの状態が変化したとき呼ばれる
+    func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
+        print(#function)
+    }
+    
+    // 他のピアによる send を受け取ったとき呼ばれる
+    func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
+        print(#function)
+    }
+    
+    // 他のピアによる sendStream を受け取ったとき呼ばれる
+    func session(_ session: MCSession, didReceive stream: InputStream, withName streamName: String, fromPeer peerID: MCPeerID) {
+        print(#function)
+        // Do nothing
+    }
+    
+    // 他のピアによる sendResource を受け取ったとき呼ばれる
+    func session(_ session: MCSession, didStartReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, with progress: Progress) {
+        print(#function)
+        // Do nothing
+    }
+    
+    // 他のピアによる sendResource を受け取ったとき呼ばれる
+    func session(_ session: MCSession, didFinishReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, at localURL: URL?, withError error: Error?) {
+        print(#function)
+        // Do nothing
+    }
+}
+
+// MARK: - MCNearbyServiceAdvertiserDelegate
+
+extension MCConnecter: MCNearbyServiceAdvertiserDelegate {
+    func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID, withContext context: Data?, invitationHandler: @escaping (Bool, MCSession?) -> Void) {
+        invitationHandler(true, session)
+    }
+}
+
+// MARK: - MCNearbyServiceBrowserDelegate
+extension MCConnecter: MCNearbyServiceBrowserDelegate {
+
+    // 接続可能なピアが見つかったとき
+    public func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String: String]?) {
+        connectableDJs.append(peerID)
+    }
+
+    // 接続可能なピアが消えたとき
+    public func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
+        connectableDJs = connectableDJs.filter { $0 != peerID }
+    }
+
+    /// エラーが起こったとき
+    public func browser(_ browser: MCNearbyServiceBrowser, didNotStartBrowsingForPeers error: Error) {
+    }
+
+}

--- a/DJYusaku/MCConnecter.swift
+++ b/DJYusaku/MCConnecter.swift
@@ -43,10 +43,6 @@ class MCConnecter: NSObject {
         browser.delegate = self
     }
     
-    func parent() -> Bool {
-        return self.isParent
-    }
-    
     func startAdvertise() {
         advertiser.startAdvertisingPeer()
     }
@@ -75,6 +71,7 @@ extension MCConnecter: MCSessionDelegate {
     // 他のピアによる send を受け取ったとき呼ばれる
     func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
         print("recieved Data: \(String(data: data, encoding: .utf8)!)")
+        print(self.delegate) // なぜかnilが返ってくる...
         DispatchQueue.main.async {
             self.delegate?.mcConnecter(didReceiveData: data, from: peerID)
         }
@@ -114,8 +111,8 @@ extension MCConnecter: MCNearbyServiceBrowserDelegate {
     public func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String: String]?) {
         self.connectableDJs.append(peerID)
             
-        print("browser: connectable  DJ is found")
-            
+        print("browser: connectable DJ is found")
+        print(self.delegate)
         DispatchQueue.main.async {
             self.delegate?.mcConnecter(connectableDevicesChanged: self.connectableDJs)
         }
@@ -123,12 +120,12 @@ extension MCConnecter: MCNearbyServiceBrowserDelegate {
 
     // 接続可能なピアが消えたとき
     public func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
-        print("browser: connectable  DJ is lost")
+        print("browser: connectable DJ is lost")
         
-        connectableDJs = connectableDJs.filter { $0 != peerID }
+        self.connectableDJs = connectableDJs.filter { $0 != peerID }
         
         DispatchQueue.main.async {
-                self.delegate?.mcConnecter(connectableDevicesChanged: self.connectableDJs)
+            self.delegate?.mcConnecter(connectableDevicesChanged: self.connectableDJs)
         }
     }
 

--- a/DJYusaku/MCConnecter.swift
+++ b/DJYusaku/MCConnecter.swift
@@ -12,12 +12,15 @@ import MultipeerConnectivity
 class MCConnecter: NSObject {
     static let shared = MCConnecter()
     
+    public weak var delegate: MCConnecterDelegate?
+    
     let serviceType = "djyusaku"
     
     var peerID :MCPeerID!
     var session: MCSession!
     var advertiser: MCNearbyServiceAdvertiser!
     var browser: MCNearbyServiceBrowser!
+
     
     var connectableDJs: [MCPeerID] = []
     
@@ -95,12 +98,25 @@ extension MCConnecter: MCNearbyServiceBrowserDelegate {
 
     // 接続可能なピアが見つかったとき
     public func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String: String]?) {
-        connectableDJs.append(peerID)
+        DispatchQueue.global().async {
+            self.connectableDJs.append(peerID)
+            
+            print("browser found")
+            
+            DispatchQueue.main.async {
+                print("async")
+                self.delegate?.mcConnecter(connectableDevicesChanged: self.connectableDJs, browser: browser)
+            }
+        }
     }
 
     // 接続可能なピアが消えたとき
     public func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
         connectableDJs = connectableDJs.filter { $0 != peerID }
+        
+        DispatchQueue.main.async {
+                self.delegate?.mcConnecter(connectableDevicesChanged: self.connectableDJs, browser: browser)
+        }
     }
 
     /// エラーが起こったとき

--- a/DJYusaku/MCConnecterDelegate.swift
+++ b/DJYusaku/MCConnecterDelegate.swift
@@ -9,16 +9,12 @@
 import Foundation
 import MultipeerConnectivity
 
-///
-/// multiPeer(didRecieveData: Data, ofType: UInt32)
-/// multiPeer(connectedDevicesChanged: [String])
-public protocol MCConnecterDelegate: class {
 
-    /// didReceiveData: delegate runs on receiving data from another peer
-    func mcConnecter(didReceiveData data: Data, ofType type: UInt32)
+protocol MCConnecterDelegate: class {
 
-    /// connectedDevicesChanged: delegate runs on connection/disconnection event in session
-    func mcConnecter(connectedDevicesChanged devices: [String])
+    // データを受け取ったとき
+    func mcConnecter(didReceiveData data: Data, from peerID: MCPeerID)
 
-    func mcConnecter(connectableDevicesChanged devices: [MCPeerID], browser: MCNearbyServiceBrowser)
+    // 接続可能なピアが見つかったとき
+    func mcConnecter(connectableDevicesChanged devices: [MCPeerID])
 }

--- a/DJYusaku/MCConnecterDelegate.swift
+++ b/DJYusaku/MCConnecterDelegate.swift
@@ -1,0 +1,24 @@
+//
+//  MCConnecterDelegate.swift
+//  DJYusaku
+//
+//  Created by Masahiro Nakamura on 2019/11/02.
+//  Copyright © 2019 Yusaku. All rights reserved.
+//
+
+import Foundation
+import MultipeerConnectivity
+
+///
+/// multiPeer(didRecieveData: Data, ofType: UInt32)
+/// multiPeer(connectedDevicesChanged: [String])
+public protocol MCConnecterDelegate: class {
+
+    /// didReceiveData: delegate runs on receiving data from another peer
+    func mcConnecter(didReceiveData data: Data, ofType type: UInt32)
+
+    /// connectedDevicesChanged: delegate runs on connection/disconnection event in session
+    func mcConnecter(connectedDevicesChanged devices: [String])
+
+    func mcConnecter(connectableDevicesChanged devices: [MCPeerID], browser: MCNearbyServiceBrowser)
+}

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -15,6 +15,8 @@ class WelcomeViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        // Debug用
         if (MCConnecter.shared.initialized && !MCConnecter.shared.isParent) {
             print(MCConnecter.shared.session.connectedPeers)
             do {
@@ -37,7 +39,6 @@ class WelcomeViewController: UIViewController {
         if (!MCConnecter.shared.initialized) {
             MCConnecter.shared.initialize(isParent: true, displayName: UIDevice.current.name)
         }
-        // MCConnecter.shared.delegate = self
         MCConnecter.shared.startAdvertise()
         self.dismiss(animated: true, completion: nil)
     }
@@ -58,9 +59,10 @@ class WelcomeViewController: UIViewController {
     
 }
 
+// MARK: - MCConnecterDelegate
 extension WelcomeViewController: MCConnecterDelegate {
+    // データが送られてきたときに実行される関数
     func mcConnecter(didReceiveData data: Data, from peerID: MCPeerID) {
-        // 受け取った
         print("\(peerID)から \(String(data: data, encoding: .utf8)!)を受け取りました")
     }
     

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -27,14 +27,13 @@ class WelcomeViewController: UIViewController {
     }
     
     @IBAction func joinAsDJ(_ sender: Any) {
-        MCConnecter.shared.initialize(isParent: true, displayName: UIDevice.current.name)
+        if (!MCConnecter.shared.initialized) {
+            MCConnecter.shared.initialize(isParent: true, displayName: UIDevice.current.name)
+        }
         MCConnecter.shared.startAdvertise()
         self.dismiss(animated: true, completion: nil)
     }
-    @IBAction func joinAsListener(_ sender: Any) {
-        NotificationCenter.default.post(name: .welcomeVCToListenerConnecterVCName, object: nil, userInfo: nil)
-        print("pushed")
-    }
+
     /*
     // MARK: - Navigation
 

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -8,16 +8,22 @@
 
 import UIKit
 
-extension Notification.Name {
-    static let welcomeVCToListenerConnecterVCName = Notification.Name("welcomeVCToListenerConnecterVCName")
-}
-
 class WelcomeViewController: UIViewController {
     
     @IBOutlet weak var doneButtonItem: UIBarButtonItem!
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        if (MCConnecter.shared.initialized) {
+            print(MCConnecter.shared.session.connectedPeers)
+            do {
+                let debugData = Data([0x44, 0x4A])
+                print(debugData)
+                try MCConnecter.shared.session.send(debugData, toPeers: MCConnecter.shared.session.connectedPeers, with: .unreliable)
+            } catch {
+                print(error)
+            }
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -30,6 +36,7 @@ class WelcomeViewController: UIViewController {
         if (!MCConnecter.shared.initialized) {
             MCConnecter.shared.initialize(isParent: true, displayName: UIDevice.current.name)
         }
+        // MCConnecter.shared.delegate = self
         MCConnecter.shared.startAdvertise()
         self.dismiss(animated: true, completion: nil)
     }

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -8,6 +8,10 @@
 
 import UIKit
 
+extension Notification.Name {
+    static let welcomeVCToListenerConnecterVCName = Notification.Name("welcomeVCToListenerConnecterVCName")
+}
+
 class WelcomeViewController: UIViewController {
     
     @IBOutlet weak var doneButtonItem: UIBarButtonItem!
@@ -26,6 +30,10 @@ class WelcomeViewController: UIViewController {
         MCConnecter.shared.initialize(isParent: true, displayName: UIDevice.current.name)
         MCConnecter.shared.startAdvertise()
         self.dismiss(animated: true, completion: nil)
+    }
+    @IBAction func joinAsListener(_ sender: Any) {
+        NotificationCenter.default.post(name: .welcomeVCToListenerConnecterVCName, object: nil, userInfo: nil)
+        print("pushed")
     }
     /*
     // MARK: - Navigation

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import MultipeerConnectivity
 
 class WelcomeViewController: UIViewController {
     
@@ -14,12 +15,12 @@ class WelcomeViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        if (MCConnecter.shared.initialized) {
+        if (MCConnecter.shared.initialized && !MCConnecter.shared.isParent) {
             print(MCConnecter.shared.session.connectedPeers)
             do {
                 let debugData = Data([0x44, 0x4A])
                 print(debugData)
-                try MCConnecter.shared.session.send(debugData, toPeers: MCConnecter.shared.session.connectedPeers, with: .unreliable)
+                try MCConnecter.shared.session.send(debugData, toPeers: [MCConnecter.shared.connectedDJ], with: .unreliable)
             } catch {
                 print(error)
             }
@@ -55,4 +56,15 @@ class WelcomeViewController: UIViewController {
         self.dismiss(animated: true, completion: nil)
     }
     
+}
+
+extension WelcomeViewController: MCConnecterDelegate {
+    func mcConnecter(didReceiveData data: Data, from peerID: MCPeerID) {
+        // 受け取った
+        print("\(peerID)から \(String(data: data, encoding: .utf8)!)を受け取りました")
+    }
+    
+    func mcConnecter(connectableDevicesChanged devices: [MCPeerID]) {
+        
+    }
 }

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -19,10 +19,14 @@ class WelcomeViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        // TODO: ペアリング画面が完成したら次のコメントアウトを外す
-        /* self.doneButtonItem.isEnabled = self.isModalInPresentation */
+        self.doneButtonItem.isEnabled = self.isModalInPresentation
     }
     
+    @IBAction func joinAsDJ(_ sender: Any) {
+        MCConnecter.shared.initialize(isParent: true, displayName: UIDevice.current.name)
+        MCConnecter.shared.startAdvertise()
+        self.dismiss(animated: true, completion: nil)
+    }
     /*
     // MARK: - Navigation
 


### PR DESCRIPTION
## 概要

MultipeerConnectivityのラッパーライブラリMCConnecter.swiftを作成。
MCConnecter.swiftで初期化、advertising、browsingが可能。
MCConnecterDelegate.swiftのメソッドを実装することで、browsing中に見つかった時の処理、データが送られてきた時の処理をかける。

## やったこと

- [x] 初期表示でのWelcomeViewControllerのDoneボタンをdisable
  - [ ] 初期表示でのWelcomeViewControllerのDoneボタンを隠す
- [x] Join as the DJボタンでセッションを初期化してadvertising開始
  - [x] 再生中の曲のインデックスの自己管理
- [x] Join as a ListenerボタンでDJ選択画面の表示 (Browsing開始)
  - [x] DJ選択画面で接続可能なDJをTableViewで表示
  - [x] DJ選択画面で表示された接続可能なDJを表すTableViewCellをタップして接続
- [ ] mcConnecter(didReceiveData data: Data, from peerID: MCPeerID)に受け取った時の処理をかけるようにする
- [ ] DJになった後に自分がDJであることをわかる表示 (ナビゲーションバーに色付け？)

#### 重要な情報

Notificationは使っていません。

デバイス間で接続するのはとりあえずできました。
送受信に関してですが、送る方は @bldsky が頑張ってます。
受け取る処理がバグってます。
(WelcomeViewControllerでのMCConnecter.shared.delegate = selfがバグってるせい？)

## やってほしいこと

「リスナは何を送ればいいか」、「DJは受け取った時何をするか」を知りたい。

それと、DJが持つReuestQueue(音楽再生のキュー)の情報を、リスナにどう送るかなどを考えなくちゃならない。(キューのリスナとの同期、リスナはキューから削除できるのか、スキップできるのかなど)