### PR TITLE
MultipeerConnectivityでデバイス間接続を可能にする

### DIFF
--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -109,7 +109,6 @@
 		C447AC99234882F900D535EB = {
 			isa = PBXGroup;
 			children = (
-				B10A9E112373F46E00209871 /* MCSession+sendRequest.swift */,
 				C447ACA4234882F900D535EB /* DJYusaku */,
 				C447ACBD234882FB00D535EB /* DJYusakuTests */,
 				C447ACC8234882FB00D535EB /* DJYusakuUITests */,
@@ -150,6 +149,7 @@
 				106B1C2C2372BE1F008684EB /* ListenerConnectableDJsTableViewCell.swift */,
 				106B1C2E2372C696008684EB /* ConnectionController.swift */,
 				106B1C302372C83F008684EB /* ConnectionControllerDelegate.swift */,
+				B10A9E112373F46E00209871 /* MCSession+sendRequest.swift */,
 			);
 			path = DJYusaku;
 			sourceTree = "<group>";

--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		106B1C2B2372BCA8008684EB /* ListenerConnectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 106B1C2A2372BCA8008684EB /* ListenerConnectionViewController.swift */; };
+		106B1C2D2372BE1F008684EB /* ListenerConnectableDJsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 106B1C2C2372BE1F008684EB /* ListenerConnectableDJsTableViewCell.swift */; };
 		411F288B23616EEB00BA96C1 /* PlayerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411F288A23616EEB00BA96C1 /* PlayerQueue.swift */; };
 		B125D88D235F426C00D383E7 /* Artwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = B125D88C235F426C00D383E7 /* Artwork.swift */; };
 		C40DC880236570DD00E80AB1 /* WelcomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40DC87F236570DD00E80AB1 /* WelcomeViewController.swift */; };
@@ -45,6 +47,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		106B1C2A2372BCA8008684EB /* ListenerConnectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListenerConnectionViewController.swift; sourceTree = "<group>"; };
+		106B1C2C2372BE1F008684EB /* ListenerConnectableDJsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListenerConnectableDJsTableViewCell.swift; sourceTree = "<group>"; };
 		411F288A23616EEB00BA96C1 /* PlayerQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerQueue.swift; sourceTree = "<group>"; };
 		B125D88C235F426C00D383E7 /* Artwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artwork.swift; sourceTree = "<group>"; };
 		C40DC87F236570DD00E80AB1 /* WelcomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeViewController.swift; sourceTree = "<group>"; };
@@ -135,6 +139,8 @@
 				B125D88C235F426C00D383E7 /* Artwork.swift */,
 				411F288A23616EEB00BA96C1 /* PlayerQueue.swift */,
 				C40DC87F236570DD00E80AB1 /* WelcomeViewController.swift */,
+				106B1C2A2372BCA8008684EB /* ListenerConnectionViewController.swift */,
+				106B1C2C2372BE1F008684EB /* ListenerConnectableDJsTableViewCell.swift */,
 			);
 			path = DJYusaku;
 			sourceTree = "<group>";
@@ -296,12 +302,14 @@
 			files = (
 				B125D88D235F426C00D383E7 /* Artwork.swift in Sources */,
 				C4CF9725235163EF00C8A102 /* SearchViewController.swift in Sources */,
+				106B1C2D2372BE1F008684EB /* ListenerConnectableDJsTableViewCell.swift in Sources */,
 				411F288B23616EEB00BA96C1 /* PlayerQueue.swift in Sources */,
 				C4FDD0CC2356EA8F007569B1 /* RequestsMusicTableViewCell.swift in Sources */,
 				C436A8562350B16B009F6498 /* Song.swift in Sources */,
 				C4D25958235205D10066FCE0 /* Secrets.swift in Sources */,
 				C447ACAA234882F900D535EB /* RequestsViewController.swift in Sources */,
 				C447ACA6234882F900D535EB /* AppDelegate.swift in Sources */,
+				106B1C2B2372BCA8008684EB /* ListenerConnectionViewController.swift in Sources */,
 				C4D2595A235205EC0066FCE0 /* Secrets+Local.swift in Sources */,
 				C40DC880236570DD00E80AB1 /* WelcomeViewController.swift in Sources */,
 				C447ACA8234882F900D535EB /* SceneDelegate.swift in Sources */,

--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		106B1C2F2372C696008684EB /* ConnectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 106B1C2E2372C696008684EB /* ConnectionController.swift */; };
 		106B1C312372C83F008684EB /* ConnectionControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 106B1C302372C83F008684EB /* ConnectionControllerDelegate.swift */; };
 		411F288B23616EEB00BA96C1 /* PlayerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411F288A23616EEB00BA96C1 /* PlayerQueue.swift */; };
+		B10A9E122373F46E00209871 /* MCSession+sendRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10A9E112373F46E00209871 /* MCSession+sendRequest.swift */; };
 		B125D88D235F426C00D383E7 /* Artwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = B125D88C235F426C00D383E7 /* Artwork.swift */; };
 		C40DC880236570DD00E80AB1 /* WelcomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40DC87F236570DD00E80AB1 /* WelcomeViewController.swift */; };
 		C436A8562350B16B009F6498 /* Song.swift in Sources */ = {isa = PBXBuildFile; fileRef = C436A8552350B16B009F6498 /* Song.swift */; };
@@ -54,6 +55,7 @@
 		106B1C2E2372C696008684EB /* ConnectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionController.swift; sourceTree = "<group>"; };
 		106B1C302372C83F008684EB /* ConnectionControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionControllerDelegate.swift; sourceTree = "<group>"; };
 		411F288A23616EEB00BA96C1 /* PlayerQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerQueue.swift; sourceTree = "<group>"; };
+		B10A9E112373F46E00209871 /* MCSession+sendRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MCSession+sendRequest.swift"; sourceTree = "<group>"; };
 		B125D88C235F426C00D383E7 /* Artwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artwork.swift; sourceTree = "<group>"; };
 		C40DC87F236570DD00E80AB1 /* WelcomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeViewController.swift; sourceTree = "<group>"; };
 		C436A8552350B16B009F6498 /* Song.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Song.swift; sourceTree = "<group>"; };
@@ -107,6 +109,7 @@
 		C447AC99234882F900D535EB = {
 			isa = PBXGroup;
 			children = (
+				B10A9E112373F46E00209871 /* MCSession+sendRequest.swift */,
 				C447ACA4234882F900D535EB /* DJYusaku */,
 				C447ACBD234882FB00D535EB /* DJYusakuTests */,
 				C447ACC8234882FB00D535EB /* DJYusakuUITests */,
@@ -318,6 +321,7 @@
 				C447ACA6234882F900D535EB /* AppDelegate.swift in Sources */,
 				106B1C2B2372BCA8008684EB /* ListenerConnectionViewController.swift in Sources */,
 				C4D2595A235205EC0066FCE0 /* Secrets+Local.swift in Sources */,
+				B10A9E122373F46E00209871 /* MCSession+sendRequest.swift in Sources */,
 				106B1C312372C83F008684EB /* ConnectionControllerDelegate.swift in Sources */,
 				C40DC880236570DD00E80AB1 /* WelcomeViewController.swift in Sources */,
 				C447ACA8234882F900D535EB /* SceneDelegate.swift in Sources */,
@@ -497,13 +501,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = SZ55PXK5GR;
+				DEVELOPMENT_TEAM = F98SMB4597;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.tsuu32;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.leney;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		106B1C2B2372BCA8008684EB /* ListenerConnectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 106B1C2A2372BCA8008684EB /* ListenerConnectionViewController.swift */; };
 		106B1C2D2372BE1F008684EB /* ListenerConnectableDJsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 106B1C2C2372BE1F008684EB /* ListenerConnectableDJsTableViewCell.swift */; };
+		106B1C2F2372C696008684EB /* ConnectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 106B1C2E2372C696008684EB /* ConnectionController.swift */; };
+		106B1C312372C83F008684EB /* ConnectionControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 106B1C302372C83F008684EB /* ConnectionControllerDelegate.swift */; };
 		411F288B23616EEB00BA96C1 /* PlayerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411F288A23616EEB00BA96C1 /* PlayerQueue.swift */; };
 		B125D88D235F426C00D383E7 /* Artwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = B125D88C235F426C00D383E7 /* Artwork.swift */; };
 		C40DC880236570DD00E80AB1 /* WelcomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40DC87F236570DD00E80AB1 /* WelcomeViewController.swift */; };
@@ -49,6 +51,8 @@
 /* Begin PBXFileReference section */
 		106B1C2A2372BCA8008684EB /* ListenerConnectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListenerConnectionViewController.swift; sourceTree = "<group>"; };
 		106B1C2C2372BE1F008684EB /* ListenerConnectableDJsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListenerConnectableDJsTableViewCell.swift; sourceTree = "<group>"; };
+		106B1C2E2372C696008684EB /* ConnectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionController.swift; sourceTree = "<group>"; };
+		106B1C302372C83F008684EB /* ConnectionControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionControllerDelegate.swift; sourceTree = "<group>"; };
 		411F288A23616EEB00BA96C1 /* PlayerQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerQueue.swift; sourceTree = "<group>"; };
 		B125D88C235F426C00D383E7 /* Artwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artwork.swift; sourceTree = "<group>"; };
 		C40DC87F236570DD00E80AB1 /* WelcomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeViewController.swift; sourceTree = "<group>"; };
@@ -141,6 +145,8 @@
 				C40DC87F236570DD00E80AB1 /* WelcomeViewController.swift */,
 				106B1C2A2372BCA8008684EB /* ListenerConnectionViewController.swift */,
 				106B1C2C2372BE1F008684EB /* ListenerConnectableDJsTableViewCell.swift */,
+				106B1C2E2372C696008684EB /* ConnectionController.swift */,
+				106B1C302372C83F008684EB /* ConnectionControllerDelegate.swift */,
 			);
 			path = DJYusaku;
 			sourceTree = "<group>";
@@ -307,10 +313,12 @@
 				C4FDD0CC2356EA8F007569B1 /* RequestsMusicTableViewCell.swift in Sources */,
 				C436A8562350B16B009F6498 /* Song.swift in Sources */,
 				C4D25958235205D10066FCE0 /* Secrets.swift in Sources */,
+				106B1C2F2372C696008684EB /* ConnectionController.swift in Sources */,
 				C447ACAA234882F900D535EB /* RequestsViewController.swift in Sources */,
 				C447ACA6234882F900D535EB /* AppDelegate.swift in Sources */,
 				106B1C2B2372BCA8008684EB /* ListenerConnectionViewController.swift in Sources */,
 				C4D2595A235205EC0066FCE0 /* Secrets+Local.swift in Sources */,
+				106B1C312372C83F008684EB /* ConnectionControllerDelegate.swift in Sources */,
 				C40DC880236570DD00E80AB1 /* WelcomeViewController.swift in Sources */,
 				C447ACA8234882F900D535EB /* SceneDelegate.swift in Sources */,
 				C436A8582350D36F009F6498 /* SearchMusicTableViewCell.swift in Sources */,
@@ -489,13 +497,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 29WP3DF4XR;
+				DEVELOPMENT_TEAM = SZ55PXK5GR;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.tsuu32;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -508,13 +516,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 29WP3DF4XR;
+				DEVELOPMENT_TEAM = SZ55PXK5GR;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.tsuu32;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -16,7 +16,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="64" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="2ub-dF-W8m">
-                                <rect key="frame" x="0.0" y="88" width="375" height="636"/>
+                                <rect key="frame" x="0.0" y="140" width="375" height="532"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="RequestsMusicTableViewCell" id="T5J-aV-tbm" customClass="RequestsMusicTableViewCell" customModule="DJYusaku" customModuleProvider="target">
@@ -338,18 +338,59 @@
         <!--Join as a listener-->
         <scene sceneID="z8Z-ZC-zfs">
             <objects>
-                <viewController id="2ZU-rh-NCc" sceneMemberID="viewController">
+                <viewController id="2ZU-rh-NCc" customClass="ListenerConnectionViewController" customModule="DJYusaku" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="TEh-b3-bIb">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="758"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="BXT-Va-ZlK">
+                                <rect key="frame" x="0.0" y="108" width="375" height="616"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="ListenerConnectableDJsTableViewCell" id="Hmp-1P-PDK" customClass="ListenerConnectableDJsTableViewCell" customModule="DJYusaku" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="28" width="375" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Hmp-1P-PDK" id="mhw-qc-RfJ">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KK9-dh-Qaa">
+                                                    <rect key="frame" x="11" y="11.333333333333336" width="352" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="KK9-dh-Qaa" secondAttribute="trailing" constant="12" id="6jQ-1j-Ifz"/>
+                                                <constraint firstItem="KK9-dh-Qaa" firstAttribute="centerY" secondItem="mhw-qc-RfJ" secondAttribute="centerY" id="9AF-nk-HgV"/>
+                                                <constraint firstItem="KK9-dh-Qaa" firstAttribute="leading" secondItem="mhw-qc-RfJ" secondAttribute="leading" constant="11" id="bMW-KF-4b4"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="djName" destination="KK9-dh-Qaa" id="M6H-OO-qg6"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                        </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="BXT-Va-ZlK" firstAttribute="top" secondItem="Kt9-XD-t6e" secondAttribute="top" id="3dl-Mo-DJP"/>
+                            <constraint firstItem="BXT-Va-ZlK" firstAttribute="bottom" secondItem="Kt9-XD-t6e" secondAttribute="bottom" id="DyI-76-mVh"/>
+                            <constraint firstItem="Kt9-XD-t6e" firstAttribute="trailing" secondItem="BXT-Va-ZlK" secondAttribute="trailing" id="LD7-ZK-2AV"/>
+                            <constraint firstItem="BXT-Va-ZlK" firstAttribute="leading" secondItem="Kt9-XD-t6e" secondAttribute="leading" id="NJo-4t-4Lf"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="Kt9-XD-t6e"/>
                     </view>
                     <navigationItem key="navigationItem" title="Join as a listener" id="dzb-SC-M7Y"/>
+                    <connections>
+                        <outlet property="tableView" destination="BXT-Va-ZlK" id="6jB-hE-X0Q"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x2a-pV-KQr" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4646" y="-678"/>
+            <point key="canvasLocation" x="4645.6000000000004" y="-678.32512315270935"/>
         </scene>
         <!--Search-->
         <scene sceneID="wg7-f3-ORb">
@@ -360,7 +401,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="64" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="wCp-R2-0r7">
-                                <rect key="frame" x="0.0" y="88" width="375" height="641"/>
+                                <rect key="frame" x="0.0" y="140" width="375" height="589"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SearchMusicTableViewCell" id="Uxy-eD-cUw" customClass="SearchMusicTableViewCell" customModule="DJYusaku" customModuleProvider="target">
@@ -392,7 +433,7 @@
                                                     </connections>
                                                 </button>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Music Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DxG-x9-Q3o">
-                                                    <rect key="frame" x="71" y="11.999999999999998" width="233" height="20.333333333333329"/>
+                                                    <rect key="frame" x="71" y="12" width="233" height="20"/>
                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -244,7 +244,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                                 <connections>
-                                    <segue destination="np9-K9-Npw" kind="show" id="03f-GL-4oG"/>
+                                    <action selector="joinAsDJ:" destination="ypK-t8-Qz5" eventType="touchUpInside" id="Cvb-jF-sgk"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RGD-qI-6Bt">
@@ -349,23 +349,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x2a-pV-KQr" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4739" y="-321"/>
-        </scene>
-        <!--Join as the DJ-->
-        <scene sceneID="utz-Cr-c0P">
-            <objects>
-                <viewController id="np9-K9-Npw" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="1eA-j5-7PN">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="758"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                        <viewLayoutGuide key="safeArea" id="llR-Fx-3vG"/>
-                    </view>
-                    <navigationItem key="navigationItem" title="Join as the DJ" id="91p-ae-J31"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="tEG-tD-Wkz" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="4738" y="-1034"/>
+            <point key="canvasLocation" x="4646" y="-678"/>
         </scene>
         <!--Search-->
         <scene sceneID="wg7-f3-ORb">

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -70,10 +70,18 @@ extension ConnectionController: MCSessionDelegate {
     // 他のピアによる send を受け取ったとき呼ばれる
     func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
         print("\(peerID)から \(String(data: data, encoding: .utf8)!)を受け取りました")
-        // TODO: bldsky が送られてき時の動作を書く
-        DispatchQueue.main.async {
-            self.delegate?.connectionController(didReceiveData: data, from: peerID)
+        
+        let song = try! JSONDecoder().decode(Song.self, from: data)
+        
+        if ConnectionController.shared.isParent {   // DJが受け取るなら
+            PlayerQueue.shared.add(with: song) {
+                // TODO: ここにリスナーへのsendを書く
+            }
+        } else {                                    // リスナーが受け取るなら
+            // TODO: ここにDJからsendされたときの処理を書く
         }
+        
+        self.delegate?.connectionController(didReceiveData: data, from: peerID)
     }
     
     // 他のピアによる sendStream を受け取ったとき呼ばれる

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -1,0 +1,131 @@
+//
+//  ConnectionController.swift
+//  DJYusaku
+//
+//  Created by Masahiro Nakamura on 2019/11/06.
+//  Copyright © 2019 Yusaku. All rights reserved.
+//
+
+import Foundation
+import MultipeerConnectivity
+
+class ConnectionController: NSObject {
+    static let shared = ConnectionController()
+    
+    public weak var delegate: ConnectionControllerDelegate?
+    
+    let serviceType = "djyusaku"
+    
+    var peerID :MCPeerID!
+    var session: MCSession!
+    var advertiser: MCNearbyServiceAdvertiser!
+    var browser: MCNearbyServiceBrowser!
+    
+    var connectableDJs: [MCPeerID] = []
+    var connectedDJ: MCPeerID!
+    
+    var isParent: Bool!
+    
+    func initialize(isParent: Bool, displayName: String) {
+        self.isParent = isParent
+        self.connectableDJs = []
+        
+        self.peerID = MCPeerID(displayName: displayName)
+        self.session = MCSession(peer: self.peerID)
+        session.delegate = self
+        
+        advertiser = MCNearbyServiceAdvertiser(peer: self.peerID, discoveryInfo: nil, serviceType: self.serviceType)
+        advertiser.delegate = self
+
+        browser = MCNearbyServiceBrowser(peer: self.peerID, serviceType: self.serviceType)
+        browser.delegate = self
+    }
+    
+    func startAdvertise() {
+        advertiser.startAdvertisingPeer()
+    }
+    
+    func startBrowse() {
+        browser.startBrowsingForPeers()
+    }
+    
+    func stopBrowse() {
+        browser.stopBrowsingForPeers()
+    }
+    
+}
+
+// MARK: - MCSessionDelegate
+
+extension ConnectionController: MCSessionDelegate {
+    // 接続ピアの状態が変化したとき呼ばれる
+    func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
+        if state == .connected {
+            print("Peer \(peerID.displayName) is connected.")
+        } else {
+            print("Peer \(peerID.displayName) is not connected.")
+        }
+    }
+    
+    // 他のピアによる send を受け取ったとき呼ばれる
+    func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
+        print("\(peerID)から \(String(data: data, encoding: .utf8)!)を受け取りました")
+        // TODO: bldsky が送られてき時の動作を書く
+        DispatchQueue.main.async {
+            self.delegate?.connectionController(didReceiveData: data, from: peerID)
+        }
+    }
+    
+    // 他のピアによる sendStream を受け取ったとき呼ばれる
+    func session(_ session: MCSession, didReceive stream: InputStream, withName streamName: String, fromPeer peerID: MCPeerID) {
+        print(#function)
+        // Do nothing
+    }
+    
+    // 他のピアによる sendResource を受け取ったとき呼ばれる
+    func session(_ session: MCSession, didStartReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, with progress: Progress) {
+        print(#function)
+        // Do nothing
+    }
+    
+    // 他のピアによる sendResource を受け取ったとき呼ばれる
+    func session(_ session: MCSession, didFinishReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, at localURL: URL?, withError error: Error?) {
+        print(#function)
+        // Do nothing
+    }
+}
+
+// MARK: - MCNearbyServiceAdvertiserDelegate
+
+extension ConnectionController: MCNearbyServiceAdvertiserDelegate {
+    func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID, withContext context: Data?, invitationHandler: @escaping (Bool, MCSession?) -> Void) {
+        invitationHandler(true, session)
+    }
+}
+
+// MARK: - MCNearbyServiceBrowserDelegate
+
+extension ConnectionController: MCNearbyServiceBrowserDelegate {
+
+    // 接続可能なピアが見つかったとき
+    public func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String: String]?) {
+        self.connectableDJs.append(peerID)
+            
+        print("browser: connectable DJ is found")
+        // print(self.delegate)
+        self.delegate?.connectionController(connectableDevicesChanged: self.connectableDJs)
+    }
+
+    // 接続可能なピアが消えたとき
+    public func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
+        print("browser: connectable DJ is lost")
+        
+        self.connectableDJs = connectableDJs.filter { $0 != peerID }
+        
+        self.delegate?.connectionController(connectableDevicesChanged: self.connectableDJs)
+    }
+    /// エラーが起こったとき
+    public func browser(_ browser: MCNearbyServiceBrowser, didNotStartBrowsingForPeers error: Error) {
+    }
+
+}

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -123,7 +123,7 @@ extension ConnectionController: MCNearbyServiceBrowserDelegate {
             
         print("browser: connectable DJ is found")
         // print(self.delegate)
-        self.delegate?.connectionController(connectableDevicesChanged: self.connectableDJs)
+        self.delegate?.connectionController(didChangeConnectableDevices: self.connectableDJs)
     }
 
     // 接続可能なピアが消えたとき
@@ -132,7 +132,7 @@ extension ConnectionController: MCNearbyServiceBrowserDelegate {
         
         self.connectableDJs = connectableDJs.filter { $0 != peerID }
         
-        self.delegate?.connectionController(connectableDevicesChanged: self.connectableDJs)
+        self.delegate?.connectionController(didChangeConnectableDevices: self.connectableDJs)
     }
     /// エラーが起こったとき
     public func browser(_ browser: MCNearbyServiceBrowser, didNotStartBrowsingForPeers error: Error) {

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -76,9 +76,11 @@ extension ConnectionController: MCSessionDelegate {
         if ConnectionController.shared.isParent {   // DJが受け取るなら
             PlayerQueue.shared.add(with: song) {
                 // TODO: ここにリスナーへのsendを書く
+//                ConnectionController.shared.session.sendRequest(data, toPeers: [peerID], with: .unreliable)
             }
         } else {                                    // リスナーが受け取るなら
             // TODO: ここにDJからsendされたときの処理を書く
+            
         }
         
         self.delegate?.connectionController(didReceiveData: data, from: peerID)

--- a/DJYusaku/ConnectionControllerDelegate.swift
+++ b/DJYusaku/ConnectionControllerDelegate.swift
@@ -14,5 +14,5 @@ protocol ConnectionControllerDelegate: class {
     func connectionController(didReceiveData data: Data, from peerID: MCPeerID)
 
     // 接続可能なピアが見つかったとき
-    func connectionController(connectableDevicesChanged devices: [MCPeerID])
+    func connectionController(didChangeConnectableDevices devices: [MCPeerID])
 }

--- a/DJYusaku/ConnectionControllerDelegate.swift
+++ b/DJYusaku/ConnectionControllerDelegate.swift
@@ -1,0 +1,18 @@
+//
+//  ConnectionControllerDelegate.swift
+//  DJYusaku
+//
+//  Created by Masahiro Nakamura on 2019/11/06.
+//  Copyright © 2019 Yusaku. All rights reserved.
+//
+
+import Foundation
+import MultipeerConnectivity
+
+protocol ConnectionControllerDelegate: class {
+    // データを受け取ったとき
+    func connectionController(didReceiveData data: Data, from peerID: MCPeerID)
+
+    // 接続可能なピアが見つかったとき
+    func connectionController(connectableDevicesChanged devices: [MCPeerID])
+}

--- a/DJYusaku/ListenerConnectableDJsTableViewCell.swift
+++ b/DJYusaku/ListenerConnectableDJsTableViewCell.swift
@@ -1,0 +1,26 @@
+//
+//  ListenerConnectableDJsTableViewCell.swift
+//  DJYusaku
+//
+//  Created by Masahiro Nakamura on 2019/11/06.
+//  Copyright © 2019 Yusaku. All rights reserved.
+//
+
+import UIKit
+
+class ListenerConnectableDJsTableViewCell: UITableViewCell {
+
+    @IBOutlet weak var djName: UILabel!
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+}

--- a/DJYusaku/ListenerConnectionViewController.swift
+++ b/DJYusaku/ListenerConnectionViewController.swift
@@ -75,7 +75,7 @@ extension ListenerConnectionViewController: ConnectionControllerDelegate {
         
     }
 
-    func connectionController(connectableDevicesChanged devices: [MCPeerID]) {
+    func connectionController(didChangeConnectableDevices devices: [MCPeerID]) {
         // browserがピアを見つけたらリロード
         DispatchQueue.main.async {
             self.tableView.reloadData()

--- a/DJYusaku/ListenerConnectionViewController.swift
+++ b/DJYusaku/ListenerConnectionViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import MultipeerConnectivity
 
 class ListenerConnectionViewController: UIViewController {
     
@@ -15,6 +16,10 @@ class ListenerConnectionViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        ConnectionController.shared.initialize(isParent: false, displayName: UIDevice.current.name)
+        ConnectionController.shared.delegate = self
+        ConnectionController.shared.startBrowse()
+        
         // tableViewのdelegate, dataSource設定
         tableView.delegate = self
         tableView.dataSource = self
@@ -37,17 +42,22 @@ class ListenerConnectionViewController: UIViewController {
 
 extension ListenerConnectionViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 1
+        return ConnectionController.shared.connectableDJs.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "ListenerConnectableDJsTableViewCell", for: indexPath) as! ListenerConnectableDJsTableViewCell
-        cell.djName?.text = "DJ"
+        let item = ConnectionController.shared.connectableDJs[indexPath.row]
+        cell.djName?.text = "DJ: " + item.displayName
 
         return cell
     }
     
      func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let selectedDJ = ConnectionController.shared.connectableDJs[indexPath.row]
+        ConnectionController.shared.browser.invitePeer(selectedDJ, to: ConnectionController.shared.session, withContext: nil, timeout: 10.0)
+        ConnectionController.shared.connectedDJ = selectedDJ
+        ConnectionController.shared.stopBrowse()
         self.dismiss(animated: true, completion: nil)
     }
 }
@@ -56,4 +66,19 @@ extension ListenerConnectionViewController: UITableViewDataSource {
 
 extension ListenerConnectionViewController: UITableViewDelegate {
     /* TODO: 未実装 */
+}
+
+// MARK: - ConnectionControllerDelegate
+
+extension ListenerConnectionViewController: ConnectionControllerDelegate {
+    func connectionController(didReceiveData data: Data, from peerID: MCPeerID) {
+        
+    }
+
+    func connectionController(connectableDevicesChanged devices: [MCPeerID]) {
+        // browserがピアを見つけたらリロード
+        DispatchQueue.main.async {
+            self.tableView.reloadData()
+        }
+    }
 }

--- a/DJYusaku/ListenerConnectionViewController.swift
+++ b/DJYusaku/ListenerConnectionViewController.swift
@@ -1,0 +1,59 @@
+//
+//  ListenerConnectionViewController.swift
+//  DJYusaku
+//
+//  Created by Masahiro Nakamura on 2019/11/06.
+//  Copyright © 2019 Yusaku. All rights reserved.
+//
+
+import UIKit
+
+class ListenerConnectionViewController: UIViewController {
+    
+    @IBOutlet weak var tableView: UITableView!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // tableViewのdelegate, dataSource設定
+        tableView.delegate = self
+        tableView.dataSource = self
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}
+
+// MARK: - UITableViewDataSource
+
+extension ListenerConnectionViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "ListenerConnectableDJsTableViewCell", for: indexPath) as! ListenerConnectableDJsTableViewCell
+        cell.djName?.text = "DJ"
+
+        return cell
+    }
+    
+     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        self.dismiss(animated: true, completion: nil)
+    }
+}
+
+// MARK: - UITableViewDelegate
+
+extension ListenerConnectionViewController: UITableViewDelegate {
+    /* TODO: 未実装 */
+}

--- a/DJYusaku/MCSession+sendRequest.swift
+++ b/DJYusaku/MCSession+sendRequest.swift
@@ -8,13 +8,12 @@
 
 import MultipeerConnectivity
 
-extension MCSession{
+extension MCSession {
     func sendRequest(_ data: Data, toPeers peerIDs: [MCPeerID], with mode: MCSessionSendDataMode, completion: (() -> (Void))? = nil) {
         do {
             try self.send(data, toPeers: peerIDs, with: mode)
             if let completion = completion { completion() }
-        }
-        catch {
+        } catch {
             print(error)
         }
     }

--- a/DJYusaku/SearchMusicTableViewCell.swift
+++ b/DJYusaku/SearchMusicTableViewCell.swift
@@ -42,7 +42,7 @@ class SearchMusicTableViewCell: UITableViewCell {
             }
         } else { // リスナーなら
             let songData = try! JSONEncoder().encode(song)
-            ConnectionController.shared.session.sendRequest(songData, toPeers: ConnectionController.shared.session.connectedPeers, with: .unreliable)
+            ConnectionController.shared.session.sendRequest(songData, toPeers: [ConnectionController.shared.connectedDJ], with: .unreliable)
             { // FIXME: sendが通ったらの実行なのでPlayerQueueに追加されたとは限らない
                 let alert = UIAlertController(title: self.song.title, message: "was requested", preferredStyle: UIAlertController.Style.alert)
                 alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))

--- a/DJYusaku/SearchMusicTableViewCell.swift
+++ b/DJYusaku/SearchMusicTableViewCell.swift
@@ -40,7 +40,7 @@ class SearchMusicTableViewCell: UITableViewCell {
                 alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
                 self.window?.rootViewController?.present(alert, animated: true)
             }
-        } else {
+        } else { // リスナーなら
             let songData = try! JSONEncoder().encode(song)
             ConnectionController.shared.session.sendRequest(songData, toPeers: ConnectionController.shared.session.connectedPeers, with: .unreliable)
             { // FIXME: sendが通ったらの実行なのでPlayerQueueに追加されたとは限らない

--- a/DJYusaku/SearchMusicTableViewCell.swift
+++ b/DJYusaku/SearchMusicTableViewCell.swift
@@ -33,12 +33,21 @@ class SearchMusicTableViewCell: UITableViewCell {
     @IBAction func sendRequest(_ sender: Any) {
         //ボタンを連続で押させないようにする
         button.isEnabled = false
-        
-        PlayerQueue.shared.add(with: song) {
-            // リクエストが完了した旨をユーザーに通知する
-            let alert = UIAlertController(title: self.song.title, message: "was requested", preferredStyle: UIAlertController.Style.alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-            self.window?.rootViewController?.present(alert, animated: true)
+        if ConnectionController.shared.isParent { // DJなら
+            PlayerQueue.shared.add(with: song) {
+                // リクエストが完了した旨をユーザーに通知する
+                let alert = UIAlertController(title: self.song.title, message: "was requested", preferredStyle: UIAlertController.Style.alert)
+                alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+                self.window?.rootViewController?.present(alert, animated: true)
+            }
+        } else {
+            let songData = try! JSONEncoder().encode(song)
+            ConnectionController.shared.session.sendRequest(songData, toPeers: ConnectionController.shared.session.connectedPeers, with: .unreliable)
+            { // FIXME: sendが通ったらの実行なのでPlayerQueueに追加されたとは限らない
+                let alert = UIAlertController(title: self.song.title, message: "was requested", preferredStyle: UIAlertController.Style.alert)
+                alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+                self.window?.rootViewController?.present(alert, animated: true)
+            }
         }
     }
 }

--- a/DJYusaku/Song.swift
+++ b/DJYusaku/Song.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-struct Song {
+struct Song : Codable {
     var title:  String      // 曲名
     var artist: String      // アーティスト名
     var artworkUrl: URL     // 画像アートワーク

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import MultipeerConnectivity
 
 class WelcomeViewController: UIViewController {
     
@@ -19,8 +20,7 @@ class WelcomeViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        // TODO: ペアリング画面が完成したら次のコメントアウトを外す
-        /* self.doneButtonItem.isEnabled = self.isModalInPresentation */
+        self.doneButtonItem.isEnabled = self.isModalInPresentation
     }
     
     /*
@@ -38,6 +38,10 @@ class WelcomeViewController: UIViewController {
     }
     
     @IBAction func joinAsDJ(_ sender: Any) {
+        ConnectionController.shared.initialize(isParent: true, displayName: UIDevice.current.name)
+        
+        ConnectionController.shared.startAdvertise()
+        
         self.dismiss(animated: true, completion: nil)
     }
 }

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -37,4 +37,7 @@ class WelcomeViewController: UIViewController {
         self.dismiss(animated: true, completion: nil)
     }
     
+    @IBAction func joinAsDJ(_ sender: Any) {
+        self.dismiss(animated: true, completion: nil)
+    }
 }

--- a/MCSession+sendRequest.swift
+++ b/MCSession+sendRequest.swift
@@ -12,6 +12,7 @@ extension MCSession{
     func sendRequest(_ data: Data, toPeers peerIDs: [MCPeerID], with mode: MCSessionSendDataMode, completion: (() -> (Void))? = nil) {
         do {
             try self.send(data, toPeers: peerIDs, with: mode)
+            if let completion = completion { completion() }
         }
         catch {
             print(error)

--- a/MCSession+sendRequest.swift
+++ b/MCSession+sendRequest.swift
@@ -1,0 +1,21 @@
+//
+//  MCSession+sendRequest.swift
+//  DJYusaku
+//
+//  Created by leney on 2019/11/07.
+//  Copyright © 2019 Yusaku. All rights reserved.
+//
+
+import MultipeerConnectivity
+
+extension MCSession{
+    func sendRequest(_ data: Data, toPeers peerIDs: [MCPeerID], with mode: MCSessionSendDataMode, completion: (() -> (Void))? = nil) {
+        do {
+            try self.send(data, toPeers: peerIDs, with: mode)
+        }
+        catch {
+            print(error)
+        }
+    }
+}
+


### PR DESCRIPTION
## 概要

MultipeerConnectivityのラッパーライブラリConnectionController.swiftを作成。
ConnectionController.swiftで初期化、advertising、browsingが可能。
ConnectionControllerDelegate.swiftのメソッドを実装することで、browsing中に見つかった時の処理、データが送られてきた時の処理をかける。

## やったこと

- [x] 初期表示でのWelcomeViewControllerのDoneボタンをdisable
  - [ ] 初期表示でのWelcomeViewControllerのDoneボタンを隠す
- [x] Join as the DJボタンでセッションを初期化してadvertising開始
  - [x] 再生中の曲のインデックスの自己管理
- [x] Join as a ListenerボタンでDJ選択画面の表示 (Browsing開始)
  - [x] DJ選択画面で接続可能なDJをTableViewで表示
  - [x] DJ選択画面で表示された接続可能なDJを表すTableViewCellをタップして接続
- [x] connectionController(didReceiveData data: Data, from peerID: MCPeerID)に受け取った時の処理をかけるようにする
- [ ] DJになった後に自分がDJであることをわかる表示 (ナビゲーションバーに色付け？)

#### 重要な情報

Notificationは使っていません。

デバイス間で接続するのはとりあえずできました。
送受信に関してですが、送る方は @bldsky が頑張ってます。
受け取る処理がバグってます。
(WelcomeViewControllerでのConnectionController.shared.delegate = selfがバグってるせい？)

## やってほしいこと

「リスナは何を送ればいいか」、「DJは受け取った時何をするか」を知りたい。

それと、DJが持つReuestQueue(音楽再生のキュー)の情報を、リスナにどう送るかなどを考えなくちゃならない。(キューのリスナとの同期、リスナはキューから削除できるのか、スキップできるのかなど)