### PR TITLE
[WIP]キューの操作をセマフォで制御して同期処理するようにした

### DIFF
--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -481,13 +481,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 29WP3DF4XR;
+				DEVELOPMENT_TEAM = J87XZSWPMZ;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.amylase;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/DJYusaku/SearchMusicTableViewCell.swift
+++ b/DJYusaku/SearchMusicTableViewCell.swift
@@ -36,9 +36,9 @@ class SearchMusicTableViewCell: UITableViewCell {
         
         PlayerQueue.shared.add(with: song) {
             // リクエストが完了した旨をユーザーに通知する
-//            let alert = UIAlertController(title: self.song.title, message: "was requested", preferredStyle: UIAlertController.Style.alert)
-//            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-//            self.window?.rootViewController?.present(alert, animated: true)
+            let alert = UIAlertController(title: self.song.title, message: "was requested", preferredStyle: UIAlertController.Style.alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+            self.window?.rootViewController?.present(alert, animated: true)
         }
     }
 }

--- a/DJYusaku/SearchMusicTableViewCell.swift
+++ b/DJYusaku/SearchMusicTableViewCell.swift
@@ -36,9 +36,9 @@ class SearchMusicTableViewCell: UITableViewCell {
         
         PlayerQueue.shared.add(with: song) {
             // リクエストが完了した旨をユーザーに通知する
-            let alert = UIAlertController(title: self.song.title, message: "was requested", preferredStyle: UIAlertController.Style.alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-            self.window?.rootViewController?.present(alert, animated: true)
+//            let alert = UIAlertController(title: self.song.title, message: "was requested", preferredStyle: UIAlertController.Style.alert)
+//            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+//            self.window?.rootViewController?.present(alert, animated: true)
         }
     }
 }


### PR DESCRIPTION
#20 

## 概要
> 再生キューへの前の操作が終わってない状態で別の操作をしようとするとアプリがクラッシュする

という問題の解決を図った

## やったこと（変更点）
- DispatchSemaphoreを使って、再生キューに同時に触れることができるスレッドを1つに限定させた

## 動作確認
- Search画面で連続的にいくつもの楽曲を追加してもアプリが落ちないことを確認

## お願い
- @yaplus __#20 を報告した時と同様の操作で確認をお願いします__
- @bldsky @tsuu32 動作確認に示した操作で確認をお願いします

## 参考
https://blog.ymyzk.com/2015/08/gcd-grand-central-dispatch-semaphore/

