### PR TITLE
RequestViewの編集機能を追加

### DIFF
--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -501,13 +501,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 29WP3DF4XR;
+				DEVELOPMENT_TEAM = J87XZSWPMZ;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.amylase;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -501,13 +501,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = J87XZSWPMZ;
+				DEVELOPMENT_TEAM = 29WP3DF4XR;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.amylase;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15509"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,7 +16,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="64" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="2ub-dF-W8m">
-                                <rect key="frame" x="0.0" y="140" width="375" height="532"/>
+                                <rect key="frame" x="0.0" y="88" width="375" height="636"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="RequestsMusicTableViewCell" id="T5J-aV-tbm" customClass="RequestsMusicTableViewCell" customModule="DJYusaku" customModuleProvider="target">

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -164,12 +164,12 @@
                         <viewLayoutGuide key="safeArea" id="PQr-Ze-W5v"/>
                     </view>
                     <navigationItem key="navigationItem" title="Requests" id="K0B-Hq-EiT">
-                        <barButtonItem key="leftBarButtonItem" title="Edit" id="9eT-eG-bit"/>
-                        <barButtonItem key="rightBarButtonItem" image="person.2.fill" catalog="system" id="u2n-sH-Den">
+                        <barButtonItem key="leftBarButtonItem" title="Session" id="u2n-sH-Den">
                             <connections>
-                                <segue destination="dBJ-r9-osw" kind="presentation" id="W7c-YK-Za5"/>
+                                <segue destination="dBJ-r9-osw" kind="presentation" id="Khf-ow-Fm0"/>
                             </connections>
                         </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" title="Edit" id="9eT-eG-bit"/>
                     </navigationItem>
                     <connections>
                         <outlet property="playButton" destination="0xl-kp-iyr" id="bMD-w6-8IJ"/>
@@ -569,7 +569,6 @@
         <image name="forward.fill" catalog="system" width="64" height="38"/>
         <image name="magnifyingglass" catalog="system" width="64" height="56"/>
         <image name="music.note.list" catalog="system" width="64" height="56"/>
-        <image name="person.2.fill" catalog="system" width="64" height="40"/>
         <image name="play.fill" catalog="system" width="58" height="64"/>
         <image name="plus" catalog="system" width="64" height="56"/>
     </resources>

--- a/DJYusaku/PlayerQueue.swift
+++ b/DJYusaku/PlayerQueue.swift
@@ -138,7 +138,7 @@ class PlayerQueue{
             // キュー中のアイテムを挿入->削除
             let descriptor = MPMusicPlayerStoreQueueDescriptor(storeIDs: [self.items[srcIndex].playbackStoreID])
             let afterIndex = dstIndex > srcIndex ? dstIndex : dstIndex-1
-            let afterItem  = afterIndex < 0      ? nil     : mutableQueue.items[afterIndex]
+            let afterItem  = afterIndex < 0      ? nil      : mutableQueue.items[afterIndex]
             mutableQueue.insert(descriptor, after: afterItem)
             mutableQueue.remove(mutableQueue.items[srcIndex])
         }, completionHandler: { [unowned self] queue, error in

--- a/DJYusaku/PlayerQueue.swift
+++ b/DJYusaku/PlayerQueue.swift
@@ -137,8 +137,8 @@ class PlayerQueue{
         self.mpAppController.perform(queueTransaction: {[unowned self] mutableQueue in
             // キュー中のアイテムを挿入->削除
             let descriptor = MPMusicPlayerStoreQueueDescriptor(storeIDs: [self.items[srcIndex].playbackStoreID])
-            let afterIndex = dstIndex > srcIndex ? dstIndex : dstIndex-1
-            let afterItem  = afterIndex < 0      ? nil      : mutableQueue.items[afterIndex]
+            let afterIndex = dstIndex   > srcIndex ? dstIndex : dstIndex-1
+            let afterItem  = afterIndex < 0        ? nil      : mutableQueue.items[afterIndex]
             mutableQueue.insert(descriptor, after: afterItem)
             mutableQueue.remove(mutableQueue.items[srcIndex])
         }, completionHandler: { [unowned self] queue, error in

--- a/DJYusaku/PlayerQueue.swift
+++ b/DJYusaku/PlayerQueue.swift
@@ -120,6 +120,60 @@ class PlayerQueue{
         })
     }
     
+    func swap(from: Int, to: Int, completion: (() -> (Void))? = nil){
+        
+        let swappedItem = items[from]
+        guard self.dispatchSemaphore.wait(timeout: .now() + 4.0) != .timedOut else {
+            // 前のキューへの追加処理が時間内に終わっていなければとりあえずリクエストを捨てる
+            DispatchQueue.main.async {
+                guard let rootViewController = (UIApplication.shared.windows.filter{$0.isKeyWindow}.first)?.rootViewController else { return }
+                let alert = UIAlertController(title: "Swap failed", message: "Queue deletion failed. Try again.", preferredStyle: UIAlertController.Style.alert)
+                alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+                rootViewController.present(alert, animated: true)
+            }
+            return
+        }
+        
+        // 対象リクエストの削除
+        self.mpAppController.perform(queueTransaction: {mutableQueue in
+            mutableQueue.remove(swappedItem)
+        }, completionHandler: { [unowned self] queue, error in
+            defer {
+                self.dispatchSemaphore.signal()
+            }
+            guard (error == nil) else { return } // TODO: 削除ができなかった時の処理
+            self.items = queue.items
+            if let completion = completion { completion() }
+            NotificationCenter.default.post(name: .DJYusakuPlayerQueueDidUpdate, object: nil)
+        })
+  
+        guard self.dispatchSemaphore.wait(timeout: .now() + 4.0) != .timedOut else {
+            // 前のキューへの追加処理が時間内に終わっていなければとりあえずリクエストを捨てる
+            DispatchQueue.main.async {
+                guard let rootViewController = (UIApplication.shared.windows.filter{$0.isKeyWindow}.first)?.rootViewController else { return }
+                let alert = UIAlertController(title: "Swap failed", message: "Queue re-insertion failed. Try again.", preferredStyle: UIAlertController.Style.alert)
+                alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+                rootViewController.present(alert, animated: true)
+            }
+            return
+        }
+        //対象リクエストの再挿入
+        self.mpAppController.perform(queueTransaction: { mutableQueue in
+            let descripter = MPMusicPlayerStoreQueueDescriptor(storeIDs: [String(swappedItem.persistentID)])
+            let insertItem = mutableQueue.items.count == 0 ? nil : mutableQueue.items[to]
+            mutableQueue.insert(descripter, after: insertItem)
+        }, completionHandler: { [unowned self] queue, error in
+            defer {
+                self.dispatchSemaphore.signal()
+            }
+            guard (error == nil) else { return } // TODO: 挿入ができなかった時の処理
+            self.items = queue.items
+            if let completion = completion { completion() }
+            NotificationCenter.default.post(name: .DJYusakuPlayerQueueDidUpdate, object: nil)
+        })
+        
+    }
+    
     func add(with song : Song, completion: (() -> (Void))? = nil) {
         if !isQueueCreated { // キューが初期化されていないとき
             self.create(with: song, completion: completion)

--- a/DJYusaku/PlayerQueue.swift
+++ b/DJYusaku/PlayerQueue.swift
@@ -25,6 +25,7 @@ class PlayerQueue{
     private var isQueueCreated: Bool = false
     
     private let dispatchSemaphore = DispatchSemaphore(value: 1)
+    private let SEMAPHORE_TIMEOUT = 2.0
     
     private init(){
         mpAppController.repeatMode = MPMusicRepeatMode.all
@@ -41,7 +42,7 @@ class PlayerQueue{
     }
     
     private func create(with song : Song, completion: (() -> (Void))? = nil) {
-        guard self.dispatchSemaphore.wait(timeout: .now() + 4.0) != .timedOut else {
+        guard self.dispatchSemaphore.wait(timeout: .now() + SEMAPHORE_TIMEOUT) != .timedOut else {
             // 前のキューへの追加処理が時間内に終わっていなければとりあえずリクエストを捨てる
             DispatchQueue.main.async {
                 guard let rootViewController = (UIApplication.shared.windows.filter{$0.isKeyWindow}.first)?.rootViewController else { return }
@@ -69,7 +70,7 @@ class PlayerQueue{
     }
 
     private func insert(after index: Int, with song : Song, completion: (() -> (Void))? = nil){
-        guard self.dispatchSemaphore.wait(timeout: .now() + 4.0) != .timedOut else {
+        guard self.dispatchSemaphore.wait(timeout: .now() + SEMAPHORE_TIMEOUT) != .timedOut else {
             // 前のキューへの追加処理が時間内に終わっていなければとりあえずリクエストを捨てる
             DispatchQueue.main.async {
                 guard let rootViewController = (UIApplication.shared.windows.filter{$0.isKeyWindow}.first)?.rootViewController else { return }
@@ -96,7 +97,7 @@ class PlayerQueue{
     }
     
     func remove(at index: Int, completion: (() -> (Void))? = nil) {
-        guard self.dispatchSemaphore.wait(timeout: .now() + 4.0) != .timedOut else {
+        guard self.dispatchSemaphore.wait(timeout: .now() + SEMAPHORE_TIMEOUT) != .timedOut else {
             // 前のキューへの追加処理が時間内に終わっていなければとりあえずリクエストを捨てる
             DispatchQueue.main.async {
                 guard let rootViewController = (UIApplication.shared.windows.filter{$0.isKeyWindow}.first)?.rootViewController else { return }
@@ -120,44 +121,34 @@ class PlayerQueue{
         })
     }
     
-    func swap(from: Int, to: Int, completion: (() -> (Void))? = nil){
+    func move(from srcIndex: Int, to dstIndex: Int, completion: (() -> (Void))? = nil){
         
-        let swappedItem = items[from]
-        guard self.dispatchSemaphore.wait(timeout: .now() + 4.0) != .timedOut else {
+        guard self.dispatchSemaphore.wait(timeout: .now() + SEMAPHORE_TIMEOUT) != .timedOut else {
             // 前のキューへの追加処理が時間内に終わっていなければとりあえずリクエストを捨てる
             DispatchQueue.main.async {
                 guard let rootViewController = (UIApplication.shared.windows.filter{$0.isKeyWindow}.first)?.rootViewController else { return }
-                let alert = UIAlertController(title: "Swap failed", message: "Swap failed. Try again.", preferredStyle: UIAlertController.Style.alert)
+                let alert = UIAlertController(title: "Move failed", message: "Swap failed. Try again.", preferredStyle: UIAlertController.Style.alert)
                 alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
                 rootViewController.present(alert, animated: true)
             }
             return
         }
         
-        // 対象リクエストの削除->再挿入
         self.mpAppController.perform(queueTransaction: {[unowned self] mutableQueue in
-            if(to - 1 < 0){ //キューの先頭にはいれないようにしてもらう
-                guard let rootViewController = (UIApplication.shared.windows.filter{$0.isKeyWindow}.first)?.rootViewController else { return }
-                let alert = UIAlertController(title: "Swap failed", message: "Cannot move item to head of queue.", preferredStyle: UIAlertController.Style.alert)
-                alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-                rootViewController.present(alert, animated: true)
-            }else{
-                mutableQueue.remove(swappedItem)
-                let mediaItemCollection = MPMediaItemCollection(items: [swappedItem])
-                let descriptor = MPMusicPlayerMediaItemQueueDescriptor(itemCollection: mediaItemCollection)
-                let insertItem = mutableQueue.items[to - 1]
-                print("insert after: " ,to-1)
-                mutableQueue.insert(descriptor, after: insertItem)
-            }
-
+            // キュー中のアイテムを挿入->削除
+            let descriptor = MPMusicPlayerStoreQueueDescriptor(storeIDs: [self.items[srcIndex].playbackStoreID])
+            let afterIndex = dstIndex > srcIndex ? dstIndex : dstIndex-1
+            let afterItem  = afterIndex < 0      ? nil     : mutableQueue.items[afterIndex]
+            mutableQueue.insert(descriptor, after: afterItem)
+            mutableQueue.remove(mutableQueue.items[srcIndex])
         }, completionHandler: { [unowned self] queue, error in
             defer {
                 self.dispatchSemaphore.signal()
             }
             guard (error == nil) else { return } // TODO: 挿入ができなかった時の処理
-                self.items = queue.items
-                if let completion = completion { completion() }
-                NotificationCenter.default.post(name: .DJYusakuPlayerQueueDidUpdate, object: nil)
+            self.items = queue.items
+            if let completion = completion { completion() }
+            NotificationCenter.default.post(name: .DJYusakuPlayerQueueDidUpdate, object: nil)
         })
     }
     

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -144,8 +144,8 @@ extension RequestsViewController: UITableViewDataSource {
     }
     
     // 編集時の動作
-    private func tableView(tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
-
+    func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+        print("Swapping...")
         if(ConnectionController.shared.isParent){ //自分がDJのとき
             PlayerQueue.shared.swap(from: sourceIndexPath.row, to: destinationIndexPath.row)
         }else{

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -133,22 +133,21 @@ extension RequestsViewController: UITableViewDataSource {
         return cell
     }
     
-    // 全セルが削除不可能（削除機能はスワイプで実装されているため）
-    private func tableView(tableView: UITableView, canEditRowAtIndexPath indexPath: NSIndexPath) -> Bool {
-        return false
+    // 全セルが削除可能
+    func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        return true
     }
     
     // 全セルが編集可能
-    private func tableView(tableView: UITableView, canMoveRowAtIndexPath indexPath: NSIndexPath) -> Bool {
+    func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
         return true
     }
     
     // 編集時の動作
-    private func tableView(tableView: UITableView, moveRowAtIndexPath sourceIndexPath: NSIndexPath, toIndexPath destinationIndexPath: NSIndexPath) {
+    private func tableView(tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
 
-            // TODO: 実装途中　remove(at: sourceIndexPath.row) -> insert(song: Song, destinationIndexPath)で実装できないのでPlayerQueue.swiftにswap()を作る
         if(ConnectionController.shared.isParent){ //自分がDJのとき
-//            PlayerQueue.shared.swap(from: sourceIndexPath, to: destinationIndexPath)
+            PlayerQueue.shared.swap(from: sourceIndexPath.row, to: destinationIndexPath.row)
         }else{
             // TODO: リスナー側の動作
         }

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -47,6 +47,8 @@ class RequestsViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(handleRequestsDidUpdate), name: .DJYusakuPlayerQueueDidUpdate, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleNowPlayingItemDidChange), name: .DJYusakuPlayerQueueNowPlayingSongDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handlePlaybackStateDidChange), name: .DJYusakuPlayerQueuePlaybackStateDidChange, object: nil)
+        
+        navigationItem.leftBarButtonItem = editButtonItem
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -108,6 +110,7 @@ class RequestsViewController: UIViewController {
     
     override func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(editing, animated: true)
+        tableView.isEditing = editing
     }
 }
 
@@ -149,12 +152,6 @@ extension RequestsViewController: UITableViewDataSource {
         }else{
             // TODO: リスナー側の動作
         }
-        
-        
-        
-        
-        
-        
     }
 }
 

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -48,7 +48,7 @@ class RequestsViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(handleNowPlayingItemDidChange), name: .DJYusakuPlayerQueueNowPlayingSongDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handlePlaybackStateDidChange), name: .DJYusakuPlayerQueuePlaybackStateDidChange, object: nil)
         
-        navigationItem.leftBarButtonItem = editButtonItem
+        navigationItem.rightBarButtonItem = editButtonItem
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -146,7 +146,7 @@ extension RequestsViewController: UITableViewDataSource {
     // 編集時の動作
     func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
         if(ConnectionController.shared.isParent){ //自分がDJのとき
-            PlayerQueue.shared.swap(from: sourceIndexPath.row, to: destinationIndexPath.row)
+            PlayerQueue.shared.move(from: sourceIndexPath.row, to: destinationIndexPath.row)
         }else{
             // TODO: リスナー側の動作
         }

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -105,6 +105,10 @@ class RequestsViewController: UIViewController {
     @IBAction func skipButton(_ sender: Any) {
         PlayerQueue.shared.mpAppController.skipToNextItem()
     }
+    
+    override func setEditing(_ editing: Bool, animated: Bool) {
+        super.setEditing(editing, animated: true)
+    }
 }
 
 // MARK: - UITableViewDataSource
@@ -124,6 +128,33 @@ extension RequestsViewController: UITableViewDataSource {
         cell.artwork.image = item.artwork?.image(at: CGSize(width: 48,height: 48))
         
         return cell
+    }
+    
+    // 全セルが削除不可能（削除機能はスワイプで実装されているため）
+    private func tableView(tableView: UITableView, canEditRowAtIndexPath indexPath: NSIndexPath) -> Bool {
+        return false
+    }
+    
+    // 全セルが編集可能
+    private func tableView(tableView: UITableView, canMoveRowAtIndexPath indexPath: NSIndexPath) -> Bool {
+        return true
+    }
+    
+    // 編集時の動作
+    private func tableView(tableView: UITableView, moveRowAtIndexPath sourceIndexPath: NSIndexPath, toIndexPath destinationIndexPath: NSIndexPath) {
+
+            // TODO: 実装途中　remove(at: sourceIndexPath.row) -> insert(song: Song, destinationIndexPath)で実装できないのでPlayerQueue.swiftにswap()を作る
+        if(ConnectionController.shared.isParent){ //自分がDJのとき
+//            PlayerQueue.shared.swap(from: sourceIndexPath, to: destinationIndexPath)
+        }else{
+            // TODO: リスナー側の動作
+        }
+        
+        
+        
+        
+        
+        
     }
 }
 

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -145,7 +145,6 @@ extension RequestsViewController: UITableViewDataSource {
     
     // 編集時の動作
     func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
-        print("Swapping...")
         if(ConnectionController.shared.isParent){ //自分がDJのとき
             PlayerQueue.shared.swap(from: sourceIndexPath.row, to: destinationIndexPath.row)
         }else{


### PR DESCRIPTION
## 概要
リクエスト内の曲の順番を入れ替える機能を追加（しようとしている）

## やったこと
- Request画面左上にある、Editを押すと編集機能が起動
- セルを入れ替えてDoneを押すとリクエスト順が入れ替わる

## 問題
- ~~キューの先頭にセルを移動させると問答無用で落ちる（mutableQueue.insertの仕様上、指定したアイテムの後ろに挿入先を設定するため　先頭に移動する時はsetQueueをする必要があると読んでいる）~~
落ちないようにしたけど相変わらず挿入はできない



- 処理順をどうするか迷っている　現状はこう
```swift
　　// 対象リクエストの削除->再挿入
        self.mpAppController.perform(queueTransaction: {mutableQueue in
            
            mutableQueue.remove(swappedItem)
            let mediaItemCollection = MPMediaItemCollection(items: [swappedItem])
            let descriptor = MPMusicPlayerMediaItemQueueDescriptor(itemCollection: mediaItemCollection)
            
            let insertItem = to - 1 < 0 ? nil : mutableQueue.items[to - 1]
            print("insert after: " ,to-1)
            mutableQueue.insert(descriptor, after: insertItem)
            
        }, completionHandler: ...
```
こうなっているが、removeとinsertを行うperformを分けて、removeのcompletionHandler内でinsertを行うperformを行うというのも考えられる
```swift
　　// 対象リクエストの削除->再挿入
        self.mpAppController.perform(queueTransaction: {mutableQueue in
            
            mutableQueue.remove(swappedItem)
            
        }, completionHandler: {   [unowned self] queue, error in
            defer {
                self.dispatchSemaphore.signal()
            }
            guard (error == nil) else { return } // TODO: 挿入ができなかった時の処理
                self.items = queue.items
                if let completion = completion { completion() }
                NotificationCenter.default.post(name: .DJYusakuPlayerQueueDidUpdate, object: nil)

               self.mpAppController.perform(queueTransaction: {mutableQueue in
                  let mediaItemCollection = MPMediaItemCollection(items: [swappedItem])
                  let descriptor = MPMusicPlayerMediaItemQueueDescriptor(itemCollection: mediaItemCollection)
            
                   // FIXME: リクエストの先頭へ移動すると落ちる
                   let insertItem = to - 1 < 0 ? nil : mutableQueue.items[to - 1]
                   print("insert after: " ,to-1)
                   mutableQueue.insert(descriptor, after: insertItem)
               },  completionHandler:{ ...
               })
        })
```
今は前者にしており、その方がまとまっててSemaphoreとの兼ね合いもやりやすい。しかし、errorが返ってきた時にどっちが原因かわからなくなる

## 参考
https://github.com/himaratsu/TableViewEditSample
http://www.cl9.info/entry/2016/02/15/213929
https://qiita.com/kagemiku/items/22b74010365723c5c4fe