### PR TITLE
DJからListenerになるときのバグを修正

### DIFF
--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -16,7 +16,7 @@ class ConnectionController: NSObject {
     
     let serviceType = "djyusaku"
     
-    var peerID :MCPeerID!
+    var peerID = MCPeerID(displayName: UIDevice.current.name)
     var session: MCSession!
     var advertiser: MCNearbyServiceAdvertiser!
     var browser: MCNearbyServiceBrowser!
@@ -29,8 +29,7 @@ class ConnectionController: NSObject {
     func initialize(isParent: Bool, displayName: String) {
         self.isParent = isParent
         self.connectableDJs.removeAll()
-        
-        self.peerID = MCPeerID(displayName: displayName)
+
         self.session = MCSession(peer: self.peerID)
         session.delegate = self
 
@@ -129,9 +128,6 @@ extension ConnectionController: MCNearbyServiceBrowserDelegate {
 
     // 接続可能なピアが見つかったとき
     public func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String: String]?) {
-        // 自分を見つけた場合何もしない
-        guard peerID.displayName != self.peerID.displayName else { return }
-
         self.connectableDJs.append(peerID)
             
         print("browser: connectable DJ (\(peerID)) is found")

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -129,16 +129,19 @@ extension ConnectionController: MCNearbyServiceBrowserDelegate {
 
     // 接続可能なピアが見つかったとき
     public func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String: String]?) {
+        // 自分を見つけた場合何もしない
+        guard peerID.displayName != self.peerID.displayName else { return }
+
         self.connectableDJs.append(peerID)
             
-        print("browser: connectable DJ is found")
+        print("browser: connectable DJ (\(peerID)) is found")
         // print(self.delegate)
         self.delegate?.connectionController(didChangeConnectableDevices: self.connectableDJs)
     }
 
     // 接続可能なピアが消えたとき
     public func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
-        print("browser: connectable DJ is lost")
+        print("browser: connectable DJ (\(peerID)) is lost")
         
         self.connectableDJs = connectableDJs.filter { $0 != peerID }
         

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -130,15 +130,11 @@ extension ConnectionController: MCNearbyServiceBrowserDelegate {
     public func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String: String]?) {
         self.connectableDJs.append(peerID)
             
-        print("browser: connectable DJ (\(peerID)) is found")
-        // print(self.delegate)
         self.delegate?.connectionController(didChangeConnectableDevices: self.connectableDJs)
     }
 
     // 接続可能なピアが消えたとき
     public func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
-        print("browser: connectable DJ (\(peerID)) is lost")
-        
         self.connectableDJs = connectableDJs.filter { $0 != peerID }
         
         self.delegate?.connectionController(didChangeConnectableDevices: self.connectableDJs)

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -28,15 +28,21 @@ class ConnectionController: NSObject {
     
     func initialize(isParent: Bool, displayName: String) {
         self.isParent = isParent
-        self.connectableDJs = []
+        self.connectableDJs.removeAll()
         
         self.peerID = MCPeerID(displayName: displayName)
         self.session = MCSession(peer: self.peerID)
         session.delegate = self
-        
+
+        if advertiser != nil {
+            self.stopAdvertise()
+        }
         advertiser = MCNearbyServiceAdvertiser(peer: self.peerID, discoveryInfo: nil, serviceType: self.serviceType)
         advertiser.delegate = self
 
+        if browser != nil {
+            self.stopBrowse()
+        }
         browser = MCNearbyServiceBrowser(peer: self.peerID, serviceType: self.serviceType)
         browser.delegate = self
     }
@@ -45,6 +51,10 @@ class ConnectionController: NSObject {
         advertiser.startAdvertisingPeer()
     }
     
+    func stopAdvertise() {
+        advertiser.stopAdvertisingPeer()
+    }
+
     func startBrowse() {
         browser.startBrowsingForPeers()
     }


### PR DESCRIPTION
## 概要
現在DJであるデバイスが [join as a Listener] を押すと、一瞬自分が見えてしまう不具合を直す。

## 現象の詳しい説明
ListenerConnectionViewController では viewDidLoad() で ConnectionController.shared.initialize() している。（このときconnectableDJsは空になる、tableviewの要素はconnectableDJsから作られる）

その後すぐConnectionController.shared.startBrowse() を始めるが、このとき DJ だったときのadvertiseを検知して表示してしまう。しかし、これはその後すぐ消える。

## やったこと
initializeするときに advertiserやbrowserがあればstopする。

initializeするときにpeerIDオブジェクトを作り直さない。

## 謎
以前までもadvertiseを止めていないのに一瞬たったら消えるのはなぜ？ (ガベージコレクション的なアレで以前のadvertiserが消える？)

そもそもなぜ自分が出てきてしまうのか？ -> a1b9bc1 で直せた（コミットメッセージ参照）

fixes #33.