### PR TITLE
子機のリクエスト画面で現在の親機が受け取ったリクエストを見られるようにする

### DIFF
--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -91,14 +91,10 @@ extension ConnectionController: MCSessionDelegate {
     func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
         print("\(peerID)から \(String(data: data, encoding: .utf8)!)を受け取りました")
         
-        if ConnectionController.shared.isParent {   // DJが受け取るなら
+        if ConnectionController.shared.isParent {   // DJがデータを受け取ったとき
             let song = try! JSONDecoder().decode(Song.self, from: data)
-            PlayerQueue.shared.add(with: song) {
-                // TODO: ここにリスナーへのsendを書く
-                // ConnectionController.shared.session.sendRequest(data, toPeers: [peerID], with: .unreliable)
-            }
-        } else {                                    // リスナーが受け取るなら
-            // TODO: ここにDJからsendされたときの処理を書く
+            PlayerQueue.shared.add(with: song)
+        } else {                                    // リスナーがデータを受け取ったとき
             let songs = try! JSONDecoder().decode([Song].self, from: data)
             receivedSongs = songs
             NotificationCenter.default.post(name: .DJYusakuPlayerQueueDidUpdate, object: nil)

--- a/DJYusaku/PlayerQueue.swift
+++ b/DJYusaku/PlayerQueue.swift
@@ -164,9 +164,10 @@ class PlayerQueue{
         return items.count
     }
     
-    func get(at index: Int) -> MPMediaItem? {
+    func get(at index: Int) -> Song? {
         guard index >= 0 && self.count() > index else { return nil }
-        return items[index]
+        let item = items[index]
+        return Song(title: item.title!, artist: item.artist!, artworkUrl: URL(fileURLWithPath: ""), id: item.playbackStoreID)
     }
     
 }

--- a/DJYusaku/PlayerQueue.swift
+++ b/DJYusaku/PlayerQueue.swift
@@ -181,10 +181,7 @@ class PlayerQueue{
         guard index >= 0 && self.count() > index else { return nil }
         let item = items[index]
         
-        let title = item.title ?? "Loading..."
-        let artist = item.artist ?? "Loading..."
-        
-        return Song(title: title, artist: artist, artworkUrl: URL(fileURLWithPath: ""), id: item.playbackStoreID)
+        return Song(title: item.title ?? "Loading...", artist: item.artist ?? "Loading...", artworkUrl: URL(fileURLWithPath: ""), id: item.playbackStoreID)
     }
     
 }

--- a/DJYusaku/PlayerQueue.swift
+++ b/DJYusaku/PlayerQueue.swift
@@ -9,7 +9,6 @@
 import Foundation
 import UIKit
 import MediaPlayer
-import MultipeerConnectivity
 
 extension Notification.Name {
     // MPMusicPlayerControllerによる通知をこちらで一旦引き受けることでタイミングを制御できるようにする

--- a/DJYusaku/PlayerQueue.swift
+++ b/DJYusaku/PlayerQueue.swift
@@ -167,7 +167,11 @@ class PlayerQueue{
     func get(at index: Int) -> Song? {
         guard index >= 0 && self.count() > index else { return nil }
         let item = items[index]
-        return Song(title: item.title!, artist: item.artist!, artworkUrl: URL(fileURLWithPath: ""), id: item.playbackStoreID)
+        
+        let title = item.title ?? "Loading..."
+        let artist = item.artist ?? "Loading..."
+        
+        return Song(title: title, artist: artist, artworkUrl: URL(fileURLWithPath: ""), id: item.playbackStoreID)
     }
     
 }

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -119,16 +119,27 @@ class RequestsViewController: UIViewController {
 extension RequestsViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return PlayerQueue.shared.count()
+        guard ConnectionController.shared.isParent != nil else { return 0 }
+        if ConnectionController.shared.isParent {
+            return PlayerQueue.shared.count()
+        } else {
+            return ConnectionController.shared.receivedSongs.count
+        }
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "RequestsMusicTableViewCell", for: indexPath) as! RequestsMusicTableViewCell
-        guard let item = PlayerQueue.shared.get(at: indexPath.row) else { return cell }
+        var song: Song
+        if ConnectionController.shared.isParent {
+            guard let s = PlayerQueue.shared.get(at: indexPath.row) else { return cell }
+            song = s
+        } else {
+            song = ConnectionController.shared.receivedSongs[indexPath.row]
+        }
         
-        cell.title.text    = item.title
-        cell.artist.text   = item.artist
-        cell.artwork.image = item.artwork?.image(at: CGSize(width: 48,height: 48))
+        cell.title.text    = song.title
+        cell.artist.text   = song.artist
+        // cell.artwork.image = item.artwork?.image(at: CGSize(width: 48,height: 48))
         
         return cell
     }

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -131,15 +131,22 @@ extension RequestsViewController: UITableViewDataSource {
         let cell = tableView.dequeueReusableCell(withIdentifier: "RequestsMusicTableViewCell", for: indexPath) as! RequestsMusicTableViewCell
         var song: Song
         if ConnectionController.shared.isParent {
-            guard let s = PlayerQueue.shared.get(at: indexPath.row) else { return cell }
-            song = s
+            guard let queueSong = PlayerQueue.shared.get(at: indexPath.row) else { return cell }
+            song = queueSong
         } else {
             song = ConnectionController.shared.receivedSongs[indexPath.row]
         }
         
         cell.title.text    = song.title
         cell.artist.text   = song.artist
-        // cell.artwork.image = item.artwork?.image(at: CGSize(width: 48,height: 48))
+        
+        DispatchQueue.global().async {
+            let image = Artwork.fetch(url: song.artworkUrl)
+            DispatchQueue.main.async {
+                cell.artwork.image = image  // 画像の取得に失敗していたらnilが入ることに注意
+                cell.artwork.setNeedsLayout()
+            }
+        }
         
         return cell
     }


### PR DESCRIPTION
### 概要

今まで子機のリクエスト画面はほぼ意味のない画面だった。このPRでは、子機のリクエスト画面で現在親機が保持しているリクエストを見られるようにする機能を追加した。

- 親機は新たな子機が接続されたとき、その子機に現在のキューを送信する（Songの配列(JSON)）
- 親機はリクエストが更新されたとき、全ての子機に現在のキューを送信する（Songの配列(JSON)）
- 子機は親機からSongの配列(JSON)が送られてきたとき、receivedSongsを更新する
  - 子機はリクエスト画面で、receivedSongsに基づきtable viewを表示する

### 重要
`PlayerQueue`のgetメソッドがSongを返すようになった

### やってほしいこと
- コードレビュー
- 実機でいろいろ動かしてみてバグが発生しないか確認