### PR TITLE
子機のnowPlayingを親機からもらって表示他

### DIFF
--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1049BAF823877093001DCFD8 /* MessageData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1049BAF723877093001DCFD8 /* MessageData.swift */; };
 		106B1C2B2372BCA8008684EB /* ListenerConnectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 106B1C2A2372BCA8008684EB /* ListenerConnectionViewController.swift */; };
 		106B1C2D2372BE1F008684EB /* ListenerConnectableDJsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 106B1C2C2372BE1F008684EB /* ListenerConnectableDJsTableViewCell.swift */; };
 		106B1C2F2372C696008684EB /* ConnectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 106B1C2E2372C696008684EB /* ConnectionController.swift */; };
@@ -51,6 +52,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1049BAF723877093001DCFD8 /* MessageData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageData.swift; sourceTree = "<group>"; };
 		106B1C2A2372BCA8008684EB /* ListenerConnectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListenerConnectionViewController.swift; sourceTree = "<group>"; };
 		106B1C2C2372BE1F008684EB /* ListenerConnectableDJsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListenerConnectableDJsTableViewCell.swift; sourceTree = "<group>"; };
 		106B1C2E2372C696008684EB /* ConnectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionController.swift; sourceTree = "<group>"; };
@@ -140,6 +142,7 @@
 				106B1C2C2372BE1F008684EB /* ListenerConnectableDJsTableViewCell.swift */,
 				106B1C2A2372BCA8008684EB /* ListenerConnectionViewController.swift */,
 				B10A9E112373F46E00209871 /* MCSession+sendRequest.swift */,
+				1049BAF723877093001DCFD8 /* MessageData.swift */,
 				411F288A23616EEB00BA96C1 /* PlayerQueue.swift */,
 				C4FDD0CB2356EA8F007569B1 /* RequestsMusicTableViewCell.swift */,
 				C447ACA9234882F900D535EB /* RequestsViewController.swift */,
@@ -316,6 +319,7 @@
 				B125D88D235F426C00D383E7 /* Artwork.swift in Sources */,
 				C4CF9725235163EF00C8A102 /* SearchViewController.swift in Sources */,
 				106B1C2D2372BE1F008684EB /* ListenerConnectableDJsTableViewCell.swift in Sources */,
+				1049BAF823877093001DCFD8 /* MessageData.swift in Sources */,
 				411F288B23616EEB00BA96C1 /* PlayerQueue.swift in Sources */,
 				C4FDD0CC2356EA8F007569B1 /* RequestsMusicTableViewCell.swift in Sources */,
 				C436A8562350B16B009F6498 /* Song.swift in Sources */,
@@ -505,13 +509,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 29WP3DF4XR;
+				DEVELOPMENT_TEAM = SZ55PXK5GR;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.tsuu32;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -93,7 +93,7 @@ extension ConnectionController: MCSessionDelegate {
                 let songsData = try! JSONEncoder().encode(songs)
                 let messageData = try! JSONEncoder().encode(MessageData(desc:  MessageData.Name.requestSongs, value: songsData))
                 do {
-                try ConnectionController.shared.session.send(messageData, toPeers: [peerID], with: .unreliable)
+                    try ConnectionController.shared.session.send(messageData, toPeers: [peerID], with: .unreliable)
                 } catch let error {
                     print(error)
                 }

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -31,7 +31,6 @@ class ConnectionController: NSObject {
     var isParent: Bool!
     
     var receivedSongs: [Song] = []
-    var receivedNowPlaying: Song!
     
     func initialize(isParent: Bool, displayName: String) {
         self.isParent = isParent
@@ -119,8 +118,7 @@ extension ConnectionController: MCSessionDelegate {
                     NotificationCenter.default.post(name: .DJYusakuPlayerQueueDidUpdate, object: nil)
                 case MessageData.Name.nowPlaying:
                     let nowPlaying = try! JSONDecoder().decode(Song.self, from: messageData.value)
-                    receivedNowPlaying = nowPlaying
-                    NotificationCenter.default.post(name: .DJYusakuConnectionControllerNowPlayingSongDidChange, object: nil, userInfo: ["song": receivedNowPlaying as Any])
+                    NotificationCenter.default.post(name: .DJYusakuConnectionControllerNowPlayingSongDidChange, object: nil, userInfo: ["song": nowPlaying as Any])
             }
         }
         

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -84,7 +84,7 @@ extension ConnectionController: MCSessionDelegate {
                     songs.append(PlayerQueue.shared.get(at: i)!)
                 }
                 let songsData = try! JSONEncoder().encode(songs)
-                let messageData = try! JSONEncoder().encode(MessageData(desc:  MessageData.requestSongs, value: songsData))
+                let messageData = try! JSONEncoder().encode(MessageData(desc:  MessageData.Name.requestSongs, value: songsData))
                 try! ConnectionController.shared.session.send(messageData, toPeers: [peerID], with: .unreliable)
             }
         } else {
@@ -102,16 +102,14 @@ extension ConnectionController: MCSessionDelegate {
         } else {                                    // リスナーがデータを受け取ったとき
             let messageData = try! JSONDecoder().decode(MessageData.self, from: data)
             switch messageData.desc {
-                case MessageData.requestSongs:
+                case MessageData.Name.requestSongs:
                     let songs = try! JSONDecoder().decode([Song].self, from: messageData.value)
                     receivedSongs = songs
                     NotificationCenter.default.post(name: .DJYusakuPlayerQueueDidUpdate, object: nil)
-                case MessageData.nowPlaying:
+                case MessageData.Name.nowPlaying:
                     let nowPlaying = try! JSONDecoder().decode(Song.self, from: messageData.value)
                     receivedNowPlaying = nowPlaying
                     NotificationCenter.default.post(name: .DJYusakuConnectionControllerNowPlayingSongDidChange, object: nil, userInfo: ["song": receivedNowPlaying as Any])
-                default:
-                    print("予期しないデータを受け取りました")
             }
         }
         

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -85,7 +85,11 @@ extension ConnectionController: MCSessionDelegate {
                 }
                 let songsData = try! JSONEncoder().encode(songs)
                 let messageData = try! JSONEncoder().encode(MessageData(desc:  MessageData.Name.requestSongs, value: songsData))
-                try! ConnectionController.shared.session.send(messageData, toPeers: [peerID], with: .unreliable)
+                do {
+                try ConnectionController.shared.session.send(messageData, toPeers: [peerID], with: .unreliable)
+                } catch let error {
+                    print(error)
+                }
             }
         } else {
             print("Peer \(peerID.displayName) is not connected.")

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -9,6 +9,10 @@
 import Foundation
 import MultipeerConnectivity
 
+extension Notification.Name {
+    static let DJYusakuConnectionControllerNowPlayingSongDidChange = Notification.Name("DJYusakuConnectionControllerNowPlayingSongDidChange")
+}
+
 class ConnectionController: NSObject {
     static let shared = ConnectionController()
     
@@ -80,7 +84,7 @@ extension ConnectionController: MCSessionDelegate {
                     songs.append(PlayerQueue.shared.get(at: i)!)
                 }
                 let songsData = try! JSONEncoder().encode(songs)
-                let messageData = try! JSONEncoder().encode(MessageData(desc: "requestSongs", value: songsData))
+                let messageData = try! JSONEncoder().encode(MessageData(desc:  MessageData.requestSongs, value: songsData))
                 try! ConnectionController.shared.session.send(messageData, toPeers: [peerID], with: .unreliable)
             }
         } else {
@@ -97,14 +101,17 @@ extension ConnectionController: MCSessionDelegate {
             PlayerQueue.shared.add(with: song)
         } else {                                    // リスナーがデータを受け取ったとき
             let messageData = try! JSONDecoder().decode(MessageData.self, from: data)
-            if messageData.desc == "requestSongs" {
-                let songs = try! JSONDecoder().decode([Song].self, from: messageData.value)
-                receivedSongs = songs
-                NotificationCenter.default.post(name: .DJYusakuPlayerQueueDidUpdate, object: nil)
-            } else if messageData.desc == "nowPlaying" {
-                let nowPlaying = try! JSONDecoder().decode(Song.self, from: messageData.value)
-                receivedNowPlaying = nowPlaying
-                NotificationCenter.default.post(name: .DJYusakuPlayerQueueNowPlayingSongDidChange, object: nil)
+            switch messageData.desc {
+                case MessageData.requestSongs:
+                    let songs = try! JSONDecoder().decode([Song].self, from: messageData.value)
+                    receivedSongs = songs
+                    NotificationCenter.default.post(name: .DJYusakuPlayerQueueDidUpdate, object: nil)
+                case MessageData.nowPlaying:
+                    let nowPlaying = try! JSONDecoder().decode(Song.self, from: messageData.value)
+                    receivedNowPlaying = nowPlaying
+                    NotificationCenter.default.post(name: .DJYusakuConnectionControllerNowPlayingSongDidChange, object: nil, userInfo: ["song": receivedNowPlaying as Any])
+                default:
+                    print("予期しないデータを受け取りました")
             }
         }
         

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -56,6 +56,7 @@ class ConnectionController: NSObject {
     }
     
     @objc func viewWillEnterForeground() {
+        guard connectedDJ != nil else { return }
         ConnectionController.shared.browser.invitePeer(connectedDJ, to: ConnectionController.shared.session, withContext: nil, timeout: 10.0)
     }
     

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -51,6 +51,12 @@ class ConnectionController: NSObject {
         }
         browser = MCNearbyServiceBrowser(peer: self.peerID, serviceType: self.serviceType)
         browser.delegate = self
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(viewWillEnterForeground), name: .DJYusakuRequestVCWillEnterForeground, object: nil)
+    }
+    
+    @objc func viewWillEnterForeground() {
+        ConnectionController.shared.browser.invitePeer(connectedDJ, to: ConnectionController.shared.session, withContext: nil, timeout: 10.0)
     }
     
     func startAdvertise() {

--- a/DJYusaku/MessageData.swift
+++ b/DJYusaku/MessageData.swift
@@ -9,9 +9,11 @@
 import UIKit
 
 struct MessageData : Codable {
-    var desc: String // 説明
+    var desc : MessageData.Name // 説明
     var value: Data   // JOSNデータ
     
-    static let nowPlaying = "nowPlaying"
-    static let requestSongs = "requestSongs"
+    enum Name: Int, Codable {
+        case nowPlaying
+        case requestSongs
+    }
 }

--- a/DJYusaku/MessageData.swift
+++ b/DJYusaku/MessageData.swift
@@ -9,7 +9,9 @@
 import UIKit
 
 struct MessageData : Codable {
-    var desc:  String // 説明
+    var desc: String // 説明
     var value: Data   // JOSNデータ
+    
+    static let nowPlaying = "nowPlaying"
+    static let requestSongs = "requestSongs"
 }
-

--- a/DJYusaku/MessageData.swift
+++ b/DJYusaku/MessageData.swift
@@ -1,0 +1,15 @@
+//
+//  MessageData.swift
+//  DJYusaku
+//
+//  Created by Masahiro Nakamura on 2019/11/22.
+//  Copyright © 2019 Yusaku. All rights reserved.
+//
+
+import UIKit
+
+struct MessageData : Codable {
+    var desc:  String // 説明
+    var value: Data   // JOSNデータ
+}
+

--- a/DJYusaku/PlayerQueue.swift
+++ b/DJYusaku/PlayerQueue.swift
@@ -30,7 +30,7 @@ class PlayerQueue{
                     songs.append(PlayerQueue.shared.get(at: i)!)
                 }
                 let songsData = try! JSONEncoder().encode(songs)
-                let messageData = try! JSONEncoder().encode(MessageData(desc: "requestSongs", value: songsData))
+                let messageData = try! JSONEncoder().encode(MessageData(desc: MessageData.requestSongs, value: songsData))
                 
                 try! ConnectionController.shared.session.send(messageData, toPeers: ConnectionController.shared.session.connectedPeers, with: .unreliable)
             }
@@ -191,6 +191,11 @@ class PlayerQueue{
                     artist:     item.artist ?? "Loading...",
                     artworkUrl: self.urlCorrespondence[item.playbackStoreID] ?? URL(fileURLWithPath: ""),
                     id:         item.playbackStoreID)
+    }
+    
+    func getArtworkURL(storeID: String) -> URL? {
+        print(self.urlCorrespondence)
+        return self.urlCorrespondence[storeID]
     }
     
 }

--- a/DJYusaku/PlayerQueue.swift
+++ b/DJYusaku/PlayerQueue.swift
@@ -30,7 +30,9 @@ class PlayerQueue{
                     songs.append(PlayerQueue.shared.get(at: i)!)
                 }
                 let songsData = try! JSONEncoder().encode(songs)
-                try! ConnectionController.shared.session.send(songsData, toPeers: ConnectionController.shared.session.connectedPeers, with: .unreliable)
+                let messageData = try! JSONEncoder().encode(MessageData(desc: "requestSongs", value: songsData))
+                
+                try! ConnectionController.shared.session.send(messageData, toPeers: ConnectionController.shared.session.connectedPeers, with: .unreliable)
             }
         }
     }

--- a/DJYusaku/PlayerQueue.swift
+++ b/DJYusaku/PlayerQueue.swift
@@ -198,7 +198,6 @@ class PlayerQueue{
     }
     
     func getArtworkURL(storeID: String) -> URL? {
-        print(self.urlCorrespondence)
         return self.urlCorrespondence[storeID]
     }
     

--- a/DJYusaku/PlayerQueue.swift
+++ b/DJYusaku/PlayerQueue.swift
@@ -30,7 +30,7 @@ class PlayerQueue{
                     songs.append(PlayerQueue.shared.get(at: i)!)
                 }
                 let songsData = try! JSONEncoder().encode(songs)
-                let messageData = try! JSONEncoder().encode(MessageData(desc: MessageData.requestSongs, value: songsData))
+                let messageData = try! JSONEncoder().encode(MessageData(desc: MessageData.Name.requestSongs, value: songsData))
                 
                 try! ConnectionController.shared.session.send(messageData, toPeers: ConnectionController.shared.session.connectedPeers, with: .unreliable)
             }

--- a/DJYusaku/PlayerQueue.swift
+++ b/DJYusaku/PlayerQueue.swift
@@ -32,7 +32,11 @@ class PlayerQueue{
                 let songsData = try! JSONEncoder().encode(songs)
                 let messageData = try! JSONEncoder().encode(MessageData(desc: MessageData.Name.requestSongs, value: songsData))
                 
-                try! ConnectionController.shared.session.send(messageData, toPeers: ConnectionController.shared.session.connectedPeers, with: .unreliable)
+                do {
+                    try ConnectionController.shared.session.send(messageData, toPeers: ConnectionController.shared.session.connectedPeers, with: .unreliable)
+                } catch let error {
+                    print(error)
+                }
             }
         }
     }

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -121,7 +121,12 @@ class RequestsViewController: UIViewController {
     }
     
     @objc func viewWillEnterForeground() {
-        NotificationCenter.default.post(name: .DJYusakuRequestVCWillEnterForeground, object: nil)
+        if !ConnectionController.shared.isParent {
+            NotificationCenter.default.post(
+                name: .DJYusakuRequestVCWillEnterForeground,
+                object: nil
+            )
+        }
     }
     
     @IBAction func playButton(_ sender: Any) {

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -50,7 +50,7 @@ class RequestsViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(handleRequestsDidUpdate), name: .DJYusakuPlayerQueueDidUpdate, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleNowPlayingItemDidChange), name: .DJYusakuPlayerQueueNowPlayingSongDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handlePlaybackStateDidChange), name: .DJYusakuPlayerQueuePlaybackStateDidChange, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(ChangeListenerNowPlaying), name: .DJYusakuConnectionControllerNowPlayingSongDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(changeListenerNowPlaying), name: .DJYusakuConnectionControllerNowPlayingSongDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(viewWillEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
         
         navigationItem.rightBarButtonItem = editButtonItem
@@ -114,7 +114,7 @@ class RequestsViewController: UIViewController {
         }
     }
     
-    @objc func ChangeListenerNowPlaying(notification: NSNotification){
+    @objc func changeListenerNowPlaying(notification: NSNotification){
         guard let song = notification.userInfo!["song"] as? Song else { return }
         let image = Artwork.fetch(url: song.artworkUrl)
         DispatchQueue.main.async {

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -80,6 +80,11 @@ class RequestsViewController: UIViewController {
             self.playingTitle.text    = nowPlayingItem.title
             self.playingArtwork.image = nowPlayingItem.artwork?.image(at: CGSize(width: 48, height: 48))
         }
+        
+        let nowPlaying = Song(title: nowPlayingItem.title!, artist: "", artworkUrl: URL(fileURLWithPath: ""), id: "")
+        let nowPlayingData = try! JSONEncoder().encode(nowPlaying)
+        let messageData = try! JSONEncoder().encode(MessageData(desc: "nowPlaing", value: nowPlayingData))
+        try! ConnectionController.shared.session.send(messageData, toPeers: ConnectionController.shared.session.connectedPeers, with: .unreliable)
     }
     
     @objc func handlePlaybackStateDidChange(notification: NSNotification) {

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -180,20 +180,20 @@ extension RequestsViewController: UITableViewDataSource {
     
     // 全セルが削除可能
     func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        return true
+        guard ConnectionController.shared.isParent != nil else { return false }
+        return ConnectionController.shared.isParent
     }
     
     // 全セルが編集可能
     func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        return true
+        guard ConnectionController.shared.isParent != nil else { return false }
+        return ConnectionController.shared.isParent
     }
     
     // 編集時の動作
     func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
-        if(ConnectionController.shared.isParent){ //自分がDJのとき
+        if ConnectionController.shared.isParent { //自分がDJのとき
             PlayerQueue.shared.move(from: sourceIndexPath.row, to: destinationIndexPath.row)
-        }else{
-            // TODO: リスナー側の動作
         }
     }
 }

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -92,7 +92,11 @@ class RequestsViewController: UIViewController {
         )
         let nowPlayingData = try! JSONEncoder().encode(nowPlaying)
         let messageData = try! JSONEncoder().encode(MessageData(desc: MessageData.Name.nowPlaying, value: nowPlayingData))
-        try! ConnectionController.shared.session.send(messageData, toPeers: ConnectionController.shared.session.connectedPeers, with: .unreliable)
+        do {
+            try ConnectionController.shared.session.send(messageData, toPeers: ConnectionController.shared.session.connectedPeers, with: .unreliable)
+        } catch let error {
+            print(error)
+        }
     }
     
     @objc func handlePlaybackStateDidChange(notification: NSNotification) {

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -91,7 +91,7 @@ class RequestsViewController: UIViewController {
             id         : ""
         )
         let nowPlayingData = try! JSONEncoder().encode(nowPlaying)
-        let messageData = try! JSONEncoder().encode(MessageData(desc: MessageData.nowPlaying, value: nowPlayingData))
+        let messageData = try! JSONEncoder().encode(MessageData(desc: MessageData.Name.nowPlaying, value: nowPlayingData))
         try! ConnectionController.shared.session.send(messageData, toPeers: ConnectionController.shared.session.connectedPeers, with: .unreliable)
     }
     

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -10,6 +10,9 @@ import UIKit
 import StoreKit
 import MediaPlayer
 
+extension Notification.Name {
+    static let DJYusakuRequestVCWillEnterForeground = Notification.Name("DJYusakuRequestVCWillEnterForeground")
+}
 class RequestsViewController: UIViewController {
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var playingArtwork: UIImageView!
@@ -48,6 +51,7 @@ class RequestsViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(handleNowPlayingItemDidChange), name: .DJYusakuPlayerQueueNowPlayingSongDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handlePlaybackStateDidChange), name: .DJYusakuPlayerQueuePlaybackStateDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(ChangeListenerNowPlaying), name: .DJYusakuConnectionControllerNowPlayingSongDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(viewWillEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
         
         navigationItem.rightBarButtonItem = editButtonItem
     }
@@ -114,6 +118,10 @@ class RequestsViewController: UIViewController {
             self.playingTitle.text    = song.title
             self.playingArtwork.image = image
         }
+    }
+    
+    @objc func viewWillEnterForeground() {
+        NotificationCenter.default.post(name: .DJYusakuRequestVCWillEnterForeground, object: nil)
     }
     
     @IBAction func playButton(_ sender: Any) {


### PR DESCRIPTION
### 概要
今まで子機のnowPlayingに何も表示されなかった。このPRで、子機は親機からnowPlayingを受け取って、子機のnowPlayingに現在の曲のタイトル、アートワークを表示する。

### 追加機能
- 子機のnowPlaying表示
  - そのためのMessageData型を追加、親から子にはMessageData型をJSONにしたものをsend
- 子はアプリをバックグラウンドから戻ったとき、親に再接続
- 子機はTableViewを編集不可能にした