### PR TITLE
子機側の接続リストに自分の端末名を表示するようにする

### DIFF
--- a/DJYusaku/MemberViewController.swift
+++ b/DJYusaku/MemberViewController.swift
@@ -25,23 +25,24 @@ class MemberViewController: UIViewController {
         
         NotificationCenter.default.addObserver(self, selector: #selector(handlePeerConnectionStateDidUpdate), name: .DJYusakuPeerConnectionStateDidUpdate, object: nil)
         
-        childPeers = ConnectionController.shared.session.connectedPeers.filter({ $0 != ConnectionController.shared.connectedDJ})
+        childPeers = ConnectionController.shared.session.connectedPeers.filter({ $0 != ConnectionController.shared.connectedDJ })
        
         DispatchQueue.main.async{
             if (ConnectionController.shared.isParent){  //親機ならば、自分の端末名を表示する
                 self.parentNameLabel.text = ConnectionController.shared.peerID.displayName
-            }else{                                      //子機ならば、接続している端末名＝親機を表示する
-                self.parentNameLabel.text = ConnectionController.shared.connectedDJ.displayName
+            }else{                                      //子機ならば、
+                self.childPeers.insert(ConnectionController.shared.peerID, at: 0) //自分の端末を子機群の先頭に挿入
+                self.parentNameLabel.text = ConnectionController.shared.connectedDJ.displayName //接続している端末名＝親機を表示する
             }
             self.tableView.reloadData()
         }
     }
     
     @objc func handlePeerConnectionStateDidUpdate() {
-        // 接続している端末＝親機はtableViewには表示しないので弾く
-        childPeers = ConnectionController.shared.session.connectedPeers.filter({ $0 != ConnectionController.shared.connectedDJ})
+        // 接続している端末＝親機はtableViewには表示しないので除去
+        childPeers = ConnectionController.shared.session.connectedPeers.filter({ $0 != ConnectionController.shared.connectedDJ })
         
-        //親が変わったときに上部のLabelを更新
+        //親が変わったときに親機表示部分のLabelを更新
         DispatchQueue.main.async{
             if (ConnectionController.shared.isParent){  //親機ならば、自分の端末名を表示する
                 self.parentNameLabel.text = ConnectionController.shared.peerID.displayName


### PR DESCRIPTION
 ## 概要
#49 の解決

## 変更点
自端末が子機である場合、viewDidLoadで子機群を登録する変数childPeersの先頭に自端末名を追加するようにした

## 動作確認について
iPhoneXRとiPad mini 5の2台の時、接続状態が正しく表示されることを確認したが、
動作確認を一応お願いします
（できれば3台の時正しく表示されるか確認したいが…）

## その他
前のプルリクで自分が書いたコメントが気に食わなかったのでちょっと修正