### PR TITLE
キューの先頭だけ移動・削除を禁止、先頭への移動を禁止

### DIFF
--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -198,13 +198,13 @@ extension RequestsViewController: UITableViewDataSource {
         return cell
     }
     
-    // 全セルが削除可能
+    // 先頭を除く全セルが削除可能
     func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         guard ConnectionController.shared.isParent != nil else { return false }
         return ConnectionController.shared.isParent && indexPath.row != 0
     }
     
-    // 全セルが編集可能
+    // 先頭を除く全セルが編集可能
     func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
         guard ConnectionController.shared.isParent != nil else { return false }
         return ConnectionController.shared.isParent && indexPath.row != 0

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -201,13 +201,13 @@ extension RequestsViewController: UITableViewDataSource {
     // 全セルが削除可能
     func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         guard ConnectionController.shared.isParent != nil else { return false }
-        return ConnectionController.shared.isParent
+        return ConnectionController.shared.isParent && indexPath.row != 0
     }
     
     // 全セルが編集可能
     func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
         guard ConnectionController.shared.isParent != nil else { return false }
-        return ConnectionController.shared.isParent
+        return ConnectionController.shared.isParent && indexPath.row != 0
     }
     
     // 編集時の動作
@@ -221,6 +221,14 @@ extension RequestsViewController: UITableViewDataSource {
 // MARK: - UITableViewDelegate
 
 extension RequestsViewController: UITableViewDelegate {
+    // キューの先頭への移動を禁止
+    func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath, toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath{
+        if proposedDestinationIndexPath.row == 0{
+            return sourceIndexPath
+        }else{
+            return proposedDestinationIndexPath
+        }
+    }
     // セルの編集時の挙動
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {


### PR DESCRIPTION
## 概要
#52 を一時的に解決するため、キューの先頭アイテムの編集・削除ができないようにし、先頭以外についても先頭に移動するような操作を受け付けないようにした

## やったこと
- UITableViewDataSourceのtableViewにより、キュー（ビュー）の先頭のアイテムの削除、編集を禁止
- UITableViewDelegateのtableViewにより、先頭以外から先頭への移動を禁止

## 動作確認
先頭が変化するような操作に関してテスト済み
再生中の曲の位置が変化するような操作はあまり深くテストしてないのでよくみておいてください…

## その他
**このプルリクをマージしても#52 を閉じないでください**
@bldsky が問題が起こらないように編集可能にする実装をしているので