### PR TITLE
タブを押した時にアイコンがバウンドするフィードバックを追加　ほか

### DIFF
--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -530,14 +530,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
-				DEVELOPMENT_TEAM = 29WP3DF4XR;
+				DEVELOPMENT_TEAM = J87XZSWPMZ;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.3;
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.amylase;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -551,14 +551,14 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
-				DEVELOPMENT_TEAM = 29WP3DF4XR;
+				DEVELOPMENT_TEAM = J87XZSWPMZ;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.3;
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.amylase;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -169,7 +169,6 @@
                                 <segue destination="oZn-cn-RSW" kind="presentation" modalPresentationStyle="fullScreen" id="2aB-me-eAW"/>
                             </connections>
                         </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" title="Edit" id="9eT-eG-bit"/>
                     </navigationItem>
                     <connections>
                         <outlet property="playButton" destination="0xl-kp-iyr" id="bMD-w6-8IJ"/>

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -588,7 +588,7 @@
         <scene sceneID="m4A-BZ-CU1">
             <objects>
                 <viewController title="Member" id="ODD-3q-aMv" customClass="MemberViewController" customModule="DJYusaku" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="4UC-dV-YyJ">
+                    <view key="view" tag="3" contentMode="scaleToFill" id="4UC-dV-YyJ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -488,7 +488,7 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="pi3-Sl-LuS"/>
                     </view>
-                    <tabBarItem key="tabBarItem" title="" id="e6F-GQ-N3B"/>
+                    <tabBarItem key="tabBarItem" tag="1" title="" id="e6F-GQ-N3B"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="24G-CH-p3I" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -695,7 +695,7 @@
         <scene sceneID="kd9-9M-IfG">
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Hcp-5O-p0T" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" tag="3" title="Session" image="person.3.fill" catalog="system" id="TBi-Pu-CWv" userLabel="Member"/>
+                    <tabBarItem key="tabBarItem" tag="2" title="Session" image="person.3.fill" catalog="system" id="TBi-Pu-CWv" userLabel="Member"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="8QL-15-Dut">
                         <rect key="frame" x="0.0" y="44" width="375" height="96"/>

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -588,7 +588,7 @@
         <scene sceneID="m4A-BZ-CU1">
             <objects>
                 <viewController title="Member" id="ODD-3q-aMv" customClass="MemberViewController" customModule="DJYusaku" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" tag="3" contentMode="scaleToFill" id="4UC-dV-YyJ">
+                    <view key="view" contentMode="scaleToFill" id="4UC-dV-YyJ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -695,7 +695,7 @@
         <scene sceneID="kd9-9M-IfG">
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Hcp-5O-p0T" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="Session" image="person.3.fill" catalog="system" id="TBi-Pu-CWv" userLabel="Member"/>
+                    <tabBarItem key="tabBarItem" tag="3" title="Session" image="person.3.fill" catalog="system" id="TBi-Pu-CWv" userLabel="Member"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="8QL-15-Dut">
                         <rect key="frame" x="0.0" y="44" width="375" height="96"/>

--- a/DJYusaku/MemberViewController.swift
+++ b/DJYusaku/MemberViewController.swift
@@ -38,6 +38,19 @@ class MemberViewController: UIViewController {
         }
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        UIView.animateKeyframes(withDuration: 0.4, delay: 0, options: [], animations: {() -> Void in
+            UIView.addKeyframe(withRelativeStartTime: 0.0, relativeDuration: 0.3, animations: {() -> Void in
+                self.parentImageView.transform = CGAffineTransform(scaleX: CGFloat(0.5), y: CGFloat(0.5))
+            })
+            UIView.addKeyframe(withRelativeStartTime: 0.4, relativeDuration: 0.3, animations: {() -> Void in
+                self.parentImageView.transform = CGAffineTransform.identity
+            })
+        }, completion: nil)
+    }
+    
     @objc func handlePeerConnectionStateDidUpdate() {
         // 接続している端末＝親機はtableViewには表示しないので除去
         childPeers = ConnectionController.shared.session.connectedPeers.filter({ $0 != ConnectionController.shared.connectedDJ })

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -28,7 +28,6 @@ class RequestsViewController: UIViewController {
         super.viewDidLoad()
         
         // tableViewのdelegate, dataSource設定
-        tableView.delegate = self
         tableView.dataSource = self
         
         let footerView = UIView()

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -27,6 +27,8 @@ class RequestsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        // tableViewのdelegate, dataSource設定
+        tableView.dataSource = self
 
         
         let footerView = UIView()

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -198,13 +198,13 @@ extension RequestsViewController: UITableViewDataSource {
         return cell
     }
     
-    // 全セルが削除可能
+    // 編集・削除機能を有効にする
     func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         guard ConnectionController.shared.isParent != nil else { return false }
         return ConnectionController.shared.isParent
     }
     
-    // 全セルが編集可能
+    // 編集機能を有効にする
     func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
         guard ConnectionController.shared.isParent != nil else { return false }
         return ConnectionController.shared.isParent
@@ -221,6 +221,15 @@ extension RequestsViewController: UITableViewDataSource {
 // MARK: - UITableViewDelegate
 
 extension RequestsViewController: UITableViewDelegate {
+    //編集だけ有効
+    func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
+        return .none
+    }
+   //編集モード時のインデントを詰める（ないとセルの左側に空白が生まれる）
+    func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
+        return false
+    }
+    
     // セルの編集時の挙動
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -52,7 +52,6 @@ class RequestsViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(changeListenerNowPlaying), name: .DJYusakuConnectionControllerNowPlayingSongDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(viewWillEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
         
-        navigationItem.rightBarButtonItem = editButtonItem
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -192,6 +191,15 @@ extension RequestsViewController: UITableViewDataSource {
                 cell.artwork.image = image  // 画像の取得に失敗していたらnilが入ることに注意
                 cell.artwork.setNeedsLayout()
             }
+        }
+        if(indexPath.row < PlayerQueue.shared.mpAppController.indexOfNowPlayingItem){
+            cell.title.alpha    = 0.3
+            cell.artist.alpha   = 0.3
+            cell.artwork.alpha  = 0.3
+        }else{
+            cell.title.alpha    = 1.0
+            cell.artist.alpha   = 1.0
+            cell.artwork.alpha  = 1.0
         }
         
         return cell

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -27,8 +27,7 @@ class RequestsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        // tableViewのdelegate, dataSource設定
-        tableView.dataSource = self
+
         
         let footerView = UIView()
         footerView.frame.size.height = tableView.rowHeight

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -198,44 +198,10 @@ extension RequestsViewController: UITableViewDataSource {
         return cell
     }
     
-    // 編集・削除機能を有効にする
+    // 編集・削除機能を無効にする
     func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        guard ConnectionController.shared.isParent != nil else { return false }
-        return ConnectionController.shared.isParent
-    }
-    
-    // 編集機能を有効にする
-    func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        guard ConnectionController.shared.isParent != nil else { return false }
-        return ConnectionController.shared.isParent
-    }
-    
-    // 編集時の動作
-    func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
-        if ConnectionController.shared.isParent { //自分がDJのとき
-            PlayerQueue.shared.move(from: sourceIndexPath.row, to: destinationIndexPath.row)
-        }
-    }
-}
-
-// MARK: - UITableViewDelegate
-
-extension RequestsViewController: UITableViewDelegate {
-    //編集だけ有効
-    func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
-        return .none
-    }
-   //編集モード時のインデントを詰める（ないとセルの左側に空白が生まれる）
-    func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
         return false
     }
-    
-    // セルの編集時の挙動
-    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        if editingStyle == .delete {
-            PlayerQueue.shared.remove(at: indexPath.row) {
-                tableView.deleteRows(at: [indexPath], with: .left)  // 必ずPlayerQueueの処理後にTableViewの更新を行う
-            }
-        }
-    }
 }
+
+

--- a/DJYusaku/TabBarController.swift
+++ b/DJYusaku/TabBarController.swift
@@ -39,7 +39,7 @@ class TabBarController: UITabBarController {
             make.centerY.equalToSuperview()
         }
         
-        self.sessionTabImageView = self.tabBar.subviews[0].subviews.first as? UIImageView
+        self.sessionTabImageView = self.tabBar.subviews[2].subviews.first as? UIImageView
         self.sessionTabImageView.contentMode = .center
     }
     
@@ -48,11 +48,14 @@ class TabBarController: UITabBarController {
         case 3:
             self.sessionTabImageView.transform = CGAffineTransform.identity
             UIView.animate(withDuration: 0.7, delay: 0, usingSpringWithDamping: 0.5, initialSpringVelocity: 1, options: .curveEaseInOut, animations: { () -> Void in
-                
-                let rotation = CGAffineTransform(rotationAngle: CGFloat(Double.pi/2))
-                self.sessionTabImageView.transform = rotation
-                
-            }, completion: nil)
+                self.sessionTabImageView.transform = CGAffineTransform(scaleX: CGFloat(1.05), y: CGFloat(1.05))
+            }, completion: {(_) in
+//                UIView.animate(withDuration: 0.7, delay: 0, usingSpringWithDamping: 0.5, initialSpringVelocity: 1, options: .curveEaseInOut, animations: { () -> Void in
+//                    self.sessionTabImageView.transform = CGAffineTransform(scaleX: CGFloat(1/1.2), y: CGFloat(1/1.2))
+//                }, completion: nil)
+            })
+
+            break
 
         default:
             break

--- a/DJYusaku/TabBarController.swift
+++ b/DJYusaku/TabBarController.swift
@@ -12,8 +12,9 @@ import SnapKit
 class TabBarController: UITabBarController {
     
     // FIXME: 変数名
-    var requestTabImageView: UIImageView!
-    var sessionTabImageView: UIImageView!
+    var requestTabImageView:  UIImageView!
+    var sessionTabImageView:  UIImageView!
+    var plusButtonView: UIButton!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -30,12 +31,12 @@ class TabBarController: UITabBarController {
         }
         
         // プラスボタンを中央のエリアに配置
-        let plusButtonView = UIButton()
-        plusButtonView.setBackgroundImage(UIImage(systemName: "plus", withConfiguration: UIImage.SymbolConfiguration.init(pointSize: 20, weight: UIImage.SymbolWeight.bold, scale: UIImage.SymbolScale.large)),
+        self.plusButtonView = UIButton()
+        self.plusButtonView.setBackgroundImage(UIImage(systemName: "plus", withConfiguration: UIImage.SymbolConfiguration.init(pointSize: 20, weight: UIImage.SymbolWeight.bold, scale: UIImage.SymbolScale.large)),
                                           for: UIControl.State.normal)
-        plusButtonView.addTarget(self, action: #selector(plusButton), for: UIControl.Event.touchUpInside)
-        centerView.addSubview(plusButtonView)
-        plusButtonView.snp.makeConstraints { (make) -> Void in
+        self.plusButtonView.addTarget(self, action: #selector(plusButton), for: UIControl.Event.touchUpInside)
+        centerView.addSubview(self.plusButtonView)
+        self.plusButtonView.snp.makeConstraints { (make) -> Void in
             make.centerX.equalToSuperview()
             make.centerY.equalToSuperview()
         }
@@ -45,6 +46,8 @@ class TabBarController: UITabBarController {
         
         self.sessionTabImageView = self.tabBar.subviews[2].subviews.first as? UIImageView
         self.sessionTabImageView.contentMode = .center
+        
+        
         
     }
     
@@ -75,7 +78,7 @@ class TabBarController: UITabBarController {
     }
     
     // 中央のプラスボタンが押されたとき
-    @objc func plusButton() {
+    @objc func plusButton() {        
         // SearchView(実際にはそのコンテナであるNavigation)を表示する
         let storyboard: UIStoryboard = self.storyboard!
         let vc = storyboard.instantiateViewController(withIdentifier: "SearchNavigation")

--- a/DJYusaku/TabBarController.swift
+++ b/DJYusaku/TabBarController.swift
@@ -47,13 +47,14 @@ class TabBarController: UITabBarController {
         switch item.tag {
         case 3:
             self.sessionTabImageView.transform = CGAffineTransform.identity
-            UIView.animate(withDuration: 0.7, delay: 0, usingSpringWithDamping: 0.5, initialSpringVelocity: 1, options: .curveEaseInOut, animations: { () -> Void in
-                self.sessionTabImageView.transform = CGAffineTransform(scaleX: CGFloat(1.05), y: CGFloat(1.05))
-            }, completion: {(_) in
-//                UIView.animate(withDuration: 0.7, delay: 0, usingSpringWithDamping: 0.5, initialSpringVelocity: 1, options: .curveEaseInOut, animations: { () -> Void in
-//                    self.sessionTabImageView.transform = CGAffineTransform(scaleX: CGFloat(1/1.2), y: CGFloat(1/1.2))
-//                }, completion: nil)
-            })
+            UIView.animateKeyframes(withDuration: 0.4, delay: 0, options: [], animations: {() -> Void in
+                UIView.addKeyframe(withRelativeStartTime: 0.05, relativeDuration: 0.3, animations: {() -> Void in
+                    self.sessionTabImageView.transform = CGAffineTransform(scaleX: CGFloat(0.8), y: CGFloat(0.8))
+                })
+                UIView.addKeyframe(withRelativeStartTime: 0.4, relativeDuration: 0.3, animations: {() -> Void in
+                    self.sessionTabImageView.transform = CGAffineTransform.identity
+                })
+            }, completion: nil)
 
             break
 

--- a/DJYusaku/TabBarController.swift
+++ b/DJYusaku/TabBarController.swift
@@ -9,6 +9,12 @@
 import UIKit
 import SnapKit
 
+enum tabButtonTagNumber: Int{
+    case requests = 0
+    case plusEmptyView = 1
+    case session = 2
+}
+
 class TabBarController: UITabBarController {
     
     // FIXME: 変数名
@@ -66,10 +72,10 @@ class TabBarController: UITabBarController {
     
     override func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
         switch item.tag {
-        case 0:
+        case tabButtonTagNumber.requests.rawValue:
             bounceAnimation(tabImageView: self.requestTabImageView)
             break
-        case 2:
+        case tabButtonTagNumber.session.rawValue:
             bounceAnimation(tabImageView: self.sessionTabImageView)
             break
         default:
@@ -78,7 +84,7 @@ class TabBarController: UITabBarController {
     }
     
     // 中央のプラスボタンが押されたとき
-    @objc func plusButton() {        
+    @objc func plusButton() {
         // SearchView(実際にはそのコンテナであるNavigation)を表示する
         let storyboard: UIStoryboard = self.storyboard!
         let vc = storyboard.instantiateViewController(withIdentifier: "SearchNavigation")

--- a/DJYusaku/TabBarController.swift
+++ b/DJYusaku/TabBarController.swift
@@ -10,6 +10,9 @@ import UIKit
 import SnapKit
 
 class TabBarController: UITabBarController {
+    
+    var requestTabImageView: UIImageView!
+    var sessionTabImageView: UIImageView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -34,6 +37,25 @@ class TabBarController: UITabBarController {
         plusButtonView.snp.makeConstraints { (make) -> Void in
             make.centerX.equalToSuperview()
             make.centerY.equalToSuperview()
+        }
+        
+        self.sessionTabImageView = self.tabBar.subviews[0].subviews.first as? UIImageView
+        self.sessionTabImageView.contentMode = .center
+    }
+    
+    override func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
+        switch item.tag {
+        case 3:
+            self.sessionTabImageView.transform = CGAffineTransform.identity
+            UIView.animate(withDuration: 0.7, delay: 0, usingSpringWithDamping: 0.5, initialSpringVelocity: 1, options: .curveEaseInOut, animations: { () -> Void in
+                
+                let rotation = CGAffineTransform(rotationAngle: CGFloat(Double.pi/2))
+                self.sessionTabImageView.transform = rotation
+                
+            }, completion: nil)
+
+        default:
+            break
         }
     }
     

--- a/DJYusaku/TabBarController.swift
+++ b/DJYusaku/TabBarController.swift
@@ -11,6 +11,7 @@ import SnapKit
 
 class TabBarController: UITabBarController {
     
+    // FIXME: 変数名
     var requestTabImageView: UIImageView!
     var sessionTabImageView: UIImageView!
 
@@ -39,25 +40,35 @@ class TabBarController: UITabBarController {
             make.centerY.equalToSuperview()
         }
         
+        self.requestTabImageView = self.tabBar.subviews[0].subviews.first as? UIImageView
+        self.requestTabImageView.contentMode = .center
+        
         self.sessionTabImageView = self.tabBar.subviews[2].subviews.first as? UIImageView
         self.sessionTabImageView.contentMode = .center
+        
+    }
+    
+    //tabBarを押した時のバウンドしているアニメーション
+    func bounceAnimation(tabImageView: UIImageView){ //FIXME: 関数名
+        tabImageView.transform = CGAffineTransform.identity
+        UIView.animateKeyframes(withDuration: 0.4, delay: 0, options: [], animations: {() -> Void in
+            UIView.addKeyframe(withRelativeStartTime: 0.0, relativeDuration: 0.3, animations: {() -> Void in
+                tabImageView.transform = CGAffineTransform(scaleX: CGFloat(0.8), y: CGFloat(0.8))
+            })
+            UIView.addKeyframe(withRelativeStartTime: 0.4, relativeDuration: 0.3, animations: {() -> Void in
+                tabImageView.transform = CGAffineTransform.identity
+            })
+        }, completion: nil)
     }
     
     override func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
         switch item.tag {
-        case 3:
-            self.sessionTabImageView.transform = CGAffineTransform.identity
-            UIView.animateKeyframes(withDuration: 0.4, delay: 0, options: [], animations: {() -> Void in
-                UIView.addKeyframe(withRelativeStartTime: 0.05, relativeDuration: 0.3, animations: {() -> Void in
-                    self.sessionTabImageView.transform = CGAffineTransform(scaleX: CGFloat(0.8), y: CGFloat(0.8))
-                })
-                UIView.addKeyframe(withRelativeStartTime: 0.4, relativeDuration: 0.3, animations: {() -> Void in
-                    self.sessionTabImageView.transform = CGAffineTransform.identity
-                })
-            }, completion: nil)
-
+        case 0:
+            bounceAnimation(tabImageView: self.requestTabImageView)
             break
-
+        case 2:
+            bounceAnimation(tabImageView: self.sessionTabImageView)
+            break
         default:
             break
         }


### PR DESCRIPTION
## 概要
- タブを押した時、今まで無反応で無機質であったところに、タブを押すとバウンドするアニメーションを追加することでユーザー体験がリッチになった
- 削除・編集機能を殺した
- グレーアウト表示を追加

## やったこと
- TabBarController.swiftにタブを押した時のアニメーション処理を追加
- アニメーションを追加するにあたり、各タブのViewにtagをそれぞれ付与
　　- requestを0、sessionを2としている
　　- @yaplusが追加したやつは使わないけど1を付与している
- RequestViewControllerに削除機能を殺しつつ編集機能だけを有効にする記述を追加

## お願い
コードレビュー並びに動作確認をお願いします
- 関数名と変数名にすこぶる自信がないのでいい名前あったらお願いします
- アニメーションの部分のプロパティでこうした方がいいと感じたら言ってください
```  swift
        UIView.animateKeyframes(withDuration: 0.4, delay: 0, options: [], animations: {() -> Void in
            UIView.addKeyframe(withRelativeStartTime: 0.0, relativeDuration: 0.3, animations: {() -> Void in
                tabImageView.transform = CGAffineTransform(scaleX: CGFloat(0.8), y: CGFloat(0.8))
            })
            UIView.addKeyframe(withRelativeStartTime: 0.4, relativeDuration: 0.3, animations: {() -> Void in
                tabImageView.transform = CGAffineTransform.identity
            })
```
ここのところ
あとunowned self入れた方がいいのかな


## その他
~~グレーアウトの機能は付けなかった（誰が着手するべきだったか忘れた…）
このプルリクで一緒に来ると想定してた場合は言ってください~~

## 参考
https://medium.com/@fumiyasakai/uitabbarcontrollerでanimationを実装するためのヒント-93b323e6c918