### PR TITLE
ConnectionController周りで落ちないようにする

### DIFF
--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -550,14 +550,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 5;
-				DEVELOPMENT_TEAM = 29WP3DF4XR;
+				DEVELOPMENT_TEAM = SZ55PXK5GR;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.5;
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.tsuu32;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -571,14 +571,14 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 5;
-				DEVELOPMENT_TEAM = 29WP3DF4XR;
+				DEVELOPMENT_TEAM = SZ55PXK5GR;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.5;
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.tsuu32;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -550,14 +550,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 5;
-				DEVELOPMENT_TEAM = SZ55PXK5GR;
+				DEVELOPMENT_TEAM = 29WP3DF4XR;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.5;
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.tsuu32;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -571,14 +571,14 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 5;
-				DEVELOPMENT_TEAM = SZ55PXK5GR;
+				DEVELOPMENT_TEAM = 29WP3DF4XR;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.5;
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.tsuu32;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -11,22 +12,22 @@
             <objects>
                 <viewController id="9pv-A4-QxB" customClass="RequestsViewController" customModule="DJYusaku" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tsR-hK-woN">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="64" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="2ub-dF-W8m">
-                                <rect key="frame" x="0.0" y="44" width="600" height="507"/>
+                                <rect key="frame" x="0.0" y="140" width="414" height="673"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="playback" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="RequestsMusicTableViewCell" id="T5J-aV-tbm" customClass="RequestsMusicTableViewCell" customModule="DJYusaku" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="600" height="64"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="64"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="T5J-aV-tbm" id="Bkg-rZ-UB5">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="64"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="64"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="TemporarySingleColored" translatesAutoresizingMaskIntoConstraints="NO" id="4BI-ax-603">
-                                                    <rect key="frame" x="15" y="8" width="48" height="48"/>
+                                                    <rect key="frame" x="20" y="8" width="48" height="48"/>
                                                     <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="48" id="VnY-OX-Jrk"/>
@@ -35,26 +36,26 @@
                                                     <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="small"/>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Music Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yug-k8-ppk">
-                                                    <rect key="frame" x="83" y="12" width="477" height="20"/>
+                                                    <rect key="frame" x="88" y="12" width="286" height="20"/>
                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Artist" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hw4-hv-Z0J">
-                                                    <rect key="frame" x="83" y="32" width="477" height="20"/>
+                                                    <rect key="frame" x="88" y="32" width="286" height="20"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView hidden="YES" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="circle.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="eYn-Ib-chP">
-                                                    <rect key="frame" x="568" y="24.5" width="16" height="15"/>
+                                                    <rect key="frame" x="382" y="24.5" width="16" height="15"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="16" id="BDz-LO-di8"/>
                                                         <constraint firstAttribute="width" constant="16" id="pX9-9c-6C6"/>
                                                     </constraints>
                                                 </imageView>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="lBC-32-BW1">
-                                                    <rect key="frame" x="47" y="27" width="32" height="32"/>
+                                                    <rect key="frame" x="52" y="27" width="32" height="32"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="32" id="L6Z-tK-GUE"/>
                                                         <constraint firstAttribute="height" constant="32" id="sG7-x8-vWG"/>
@@ -88,7 +89,7 @@
                                 </prototypes>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9aA-O6-Z64" userLabel="PlayerControllerVIew">
-                                <rect key="frame" x="170" y="455" width="260" height="80"/>
+                                <rect key="frame" x="77" y="717" width="260" height="80"/>
                                 <subviews>
                                     <button opaque="NO" alpha="0.75" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sYe-8j-hTb">
                                         <rect key="frame" x="178" y="8" width="64" height="64"/>
@@ -199,11 +200,11 @@
             <objects>
                 <viewController title="Welcome" id="ypK-t8-Qz5" customClass="WelcomeViewController" customModule="DJYusaku" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="zoG-Zx-5x5">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DJYusaku" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Reu-FC-yfo">
-                                <rect key="frame" x="201.5" y="247" width="197" height="48"/>
+                                <rect key="frame" x="108.5" y="361" width="197" height="48"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="197" id="wTQ-Mb-K14"/>
                                     <constraint firstAttribute="height" constant="48" id="zZw-vM-6Rb"/>
@@ -213,7 +214,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome to" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dR8-x5-j8x">
-                                <rect key="frame" x="218.5" y="220" width="163" height="39"/>
+                                <rect key="frame" x="125.5" y="334" width="163" height="39"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="163" id="AxE-wQ-SGr"/>
                                     <constraint firstAttribute="height" constant="39" id="hit-fz-Dwm"/>
@@ -223,14 +224,14 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Temporary" translatesAutoresizingMaskIntoConstraints="NO" id="xNr-cQ-Ez8">
-                                <rect key="frame" x="268" y="152" width="64" height="64"/>
+                                <rect key="frame" x="175" y="266" width="64" height="64"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="64" id="gxc-hK-Pxf"/>
                                     <constraint firstAttribute="height" constant="64" id="pmc-KC-wEp"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" restorationIdentifier="AppDescription" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T1E-kF-s34">
-                                <rect key="frame" x="26.5" y="294" width="547" height="68"/>
+                                <rect key="frame" x="35" y="408" width="344.5" height="68"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="68" id="F70-6m-b3s"/>
                                 </constraints>
@@ -240,7 +241,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="90a-jE-PNH">
-                                <rect key="frame" x="204" y="374" width="192" height="40"/>
+                                <rect key="frame" x="111" y="488" width="192" height="40"/>
                                 <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="192" id="G9t-OP-ct4"/>
@@ -260,7 +261,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RGD-qI-6Bt">
-                                <rect key="frame" x="204" y="449" width="192" height="40"/>
+                                <rect key="frame" x="111" y="563" width="192" height="40"/>
                                 <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="H84-Zd-TC5"/>
@@ -280,7 +281,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="requires Apple Music contract" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QLv-BI-r7q">
-                                <rect key="frame" x="215" y="418" width="170" height="15"/>
+                                <rect key="frame" x="122" y="532" width="170" height="15"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="170" id="cCO-Td-nBq"/>
                                     <constraint firstAttribute="height" constant="15" id="cc6-Nq-aFY"/>
@@ -290,13 +291,13 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="© 2019 Yusaku" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S0h-WO-K7i">
-                                <rect key="frame" x="257" y="529" width="86" height="14.5"/>
+                                <rect key="frame" x="164" y="643" width="86" height="14.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="connects with other DJ or listener friends" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yF5-8q-DJM">
-                                <rect key="frame" x="180" y="493" width="240" height="15"/>
+                                <rect key="frame" x="87" y="607" width="240" height="15"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="15" id="Lrv-Af-sUi"/>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="240" id="onw-Gr-SY3"/>
@@ -352,34 +353,47 @@
             <objects>
                 <viewController id="2ZU-rh-NCc" customClass="ListenerConnectionViewController" customModule="DJYusaku" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="TEh-b3-bIb">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="BXT-Va-ZlK">
-                                <rect key="frame" x="0.0" y="108" width="600" height="472"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="64" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="BXT-Va-ZlK">
+                                <rect key="frame" x="0.0" y="108" width="414" height="700"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="ListenerConnectableDJsTableViewCell" id="Hmp-1P-PDK" customClass="ListenerConnectableDJsTableViewCell" customModule="DJYusaku" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="600" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="64"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Hmp-1P-PDK" id="mhw-qc-RfJ">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="64"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KK9-dh-Qaa">
-                                                    <rect key="frame" x="11" y="11.5" width="577" height="21"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KK9-dh-Qaa">
+                                                    <rect key="frame" x="64" y="22" width="334" height="20"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="20" id="7nV-4J-FpJ"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="21"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="TemporarySingleColored" translatesAutoresizingMaskIntoConstraints="NO" id="Ynj-sW-L7l" userLabel="PeerImage">
+                                                    <rect key="frame" x="8" y="8" width="48" height="48"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="48" id="f4H-6d-uzd"/>
+                                                        <constraint firstAttribute="width" constant="48" id="nd0-Zd-QY9"/>
+                                                    </constraints>
+                                                </imageView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="KK9-dh-Qaa" secondAttribute="trailing" constant="12" id="6jQ-1j-Ifz"/>
+                                                <constraint firstAttribute="trailing" secondItem="KK9-dh-Qaa" secondAttribute="trailing" constant="16" id="6jQ-1j-Ifz"/>
                                                 <constraint firstItem="KK9-dh-Qaa" firstAttribute="centerY" secondItem="mhw-qc-RfJ" secondAttribute="centerY" id="9AF-nk-HgV"/>
-                                                <constraint firstItem="KK9-dh-Qaa" firstAttribute="leading" secondItem="mhw-qc-RfJ" secondAttribute="leading" constant="11" id="bMW-KF-4b4"/>
+                                                <constraint firstItem="Ynj-sW-L7l" firstAttribute="leading" secondItem="mhw-qc-RfJ" secondAttribute="leading" constant="8" id="WNg-NB-GZ6"/>
+                                                <constraint firstItem="KK9-dh-Qaa" firstAttribute="leading" secondItem="Ynj-sW-L7l" secondAttribute="trailing" constant="8" id="bvY-Zb-7DP"/>
+                                                <constraint firstItem="Ynj-sW-L7l" firstAttribute="centerY" secondItem="mhw-qc-RfJ" secondAttribute="centerY" id="piQ-I4-YNQ"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
+                                            <outlet property="djImageView" destination="Ynj-sW-L7l" id="ySk-CX-KIu"/>
                                             <outlet property="djName" destination="KK9-dh-Qaa" id="M6H-OO-qg6"/>
                                         </connections>
                                     </tableViewCell>
@@ -402,29 +416,29 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x2a-pV-KQr" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1729" y="1727"/>
+            <point key="canvasLocation" x="1728.985507246377" y="1726.3392857142856"/>
         </scene>
         <!--New Request-->
         <scene sceneID="wg7-f3-ORb">
             <objects>
                 <viewController id="8rJ-Kc-sve" customClass="SearchViewController" customModule="DJYusaku" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="QS5-Rx-YEW">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="64" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="wCp-R2-0r7">
-                                <rect key="frame" x="0.0" y="44" width="600" height="556"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SearchMusicTableViewCell" id="Uxy-eD-cUw" customClass="SearchMusicTableViewCell" customModule="DJYusaku" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="600" height="64"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="64"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Uxy-eD-cUw" id="jsM-e1-0mc">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="64"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="64"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="TemporarySingleColored" translatesAutoresizingMaskIntoConstraints="NO" id="rYB-jY-hDQ">
-                                                    <rect key="frame" x="15" y="8" width="48" height="48"/>
+                                                    <rect key="frame" x="20" y="8" width="48" height="48"/>
                                                     <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="48" id="Pry-Xv-Br7"/>
@@ -433,13 +447,13 @@
                                                     <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="small"/>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Music Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DxG-x9-Q3o">
-                                                    <rect key="frame" x="71" y="12" width="513" height="20"/>
+                                                    <rect key="frame" x="76" y="12" width="322" height="20"/>
                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Artist" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UVM-Kb-uf9">
-                                                    <rect key="frame" x="71" y="31.5" width="513" height="21"/>
+                                                    <rect key="frame" x="76" y="31.5" width="322" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
@@ -495,7 +509,7 @@
             <objects>
                 <viewController id="4uZ-Wj-ld5" customClass="DummyViewController" customModule="DJYusaku" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="lsb-Hs-IUt">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="pi3-Sl-LuS"/>
@@ -511,7 +525,7 @@
             <objects>
                 <viewController id="oZn-cn-RSW" customClass="BatterySaverViewController" customModule="DJYusaku" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="JaV-wB-E59">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <viewLayoutGuide key="safeArea" id="ioa-To-8ez"/>
@@ -601,18 +615,18 @@
             <objects>
                 <viewController title="Member" id="ODD-3q-aMv" customClass="MemberViewController" customModule="DJYusaku" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="4UC-dV-YyJ">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="ljm-v3-8g9">
-                                <rect key="frame" x="0.0" y="298" width="600" height="253"/>
+                                <rect key="frame" x="0.0" y="342" width="414" height="471"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MemberTableViewCell" id="MsJ-dR-GdV" customClass="MemberTableViewCell" customModule="DJYusaku" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="600" height="44"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="MsJ-dR-GdV" id="Oji-6z-nXc">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="TemporarySingleColored" translatesAutoresizingMaskIntoConstraints="NO" id="fpU-yS-Emb" userLabel="PeerImage">
@@ -623,7 +637,7 @@
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WKd-f8-to8" userLabel="PeerName">
-                                                    <rect key="frame" x="63" y="11.5" width="529" height="21"/>
+                                                    <rect key="frame" x="63" y="11.5" width="343" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="21" id="jru-If-yFn"/>
                                                     </constraints>
@@ -650,20 +664,20 @@
                                 </prototypes>
                             </tableView>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="TemporarySingleColored" translatesAutoresizingMaskIntoConstraints="NO" id="KmF-kX-f76" userLabel="PeerImage">
-                                <rect key="frame" x="236" y="67" width="128" height="128"/>
+                                <rect key="frame" x="143" y="111" width="128" height="128"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="128" id="KBs-ay-c8n"/>
                                     <constraint firstAttribute="width" constant="128" id="iTt-bB-YCZ"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yP3-9N-fvb" userLabel="DJName">
-                                <rect key="frame" x="40" y="203" width="520" height="33.5"/>
+                                <rect key="frame" x="40" y="247" width="334" height="33.5"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="28"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Connecting" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Zn-fy-Vhb">
-                                <rect key="frame" x="40" y="236.5" width="520" height="17"/>
+                                <rect key="frame" x="40" y="280.5" width="334" height="17"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -713,11 +727,11 @@
             <objects>
                 <viewController id="qtf-Dc-n8Z" customClass="SettingViewController" customModule="DJYusaku" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="hC5-aW-GQe">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lXo-5K-OL8">
-                                <rect key="frame" x="180" y="317.5" width="240" height="50"/>
+                                <rect key="frame" x="87" y="470.5" width="240" height="50"/>
                                 <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="JQb-HJ-fbf"/>
@@ -736,7 +750,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Connecting DJYusaku with Twitter, you can show your nickname and profile picture." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="N8Y-QS-Ksn">
-                                <rect key="frame" x="50" y="265.5" width="500" height="36"/>
+                                <rect key="frame" x="50" y="418.5" width="314" height="36"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -86,9 +86,6 @@ class ConnectionController: NSObject {
         
         isDJ = true
         advertiser.startAdvertisingPeer()
-        if browser != nil {
-            browser.stopBrowsingForPeers()
-        }
     }
     
     func startListener(selectedDJ: MCPeerID) {

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -166,7 +166,6 @@ extension ConnectionController: MCSessionDelegate {
             }
         }
         
-        self.delegate?.connectionController(didReceiveData: data, from: peerID)
     }
     
     // 他のピアによる sendStream を受け取ったとき呼ばれる

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -28,49 +28,35 @@ class ConnectionController: NSObject {
     var advertiser: MCNearbyServiceAdvertiser!
     var browser: MCNearbyServiceBrowser!
     
-    var connectableDJs: [MCPeerID] = []
-    var connectedDJ: MCPeerID!
+    private(set) var isInitialized = false
     
-    var isDJ: Bool!
+    var isDJ: Bool? = nil
+    
+    // Listener 用
+    var connectableDJs: [MCPeerID] = []
+    var connectableDJNameCorrespondence : [MCPeerID:(String, String?)] = [:]
+    var connectedDJ: MCPeerID? = nil
     
     var receivedSongs: [Song] = []
     
     var profile: PeerProfile? = nil
     var peerProfileCorrespondence: [MCPeerID:PeerProfile] = [:]
     
-    func initialize(isDJ: Bool, displayName: String) {
-        self.isDJ = isDJ
-        self.connectableDJs.removeAll()
-
-        self.session = MCSession(peer: self.peerID)
+    func initialize() {
+        session = MCSession(peer: self.peerID)
         session.delegate = self
 
-        if advertiser != nil {
-            self.stopAdvertise()
-        }
-        advertiser = MCNearbyServiceAdvertiser(peer: self.peerID, discoveryInfo: nil, serviceType: self.serviceType)
-        advertiser.delegate = self
-
-        if browser != nil {
-            self.stopBrowse()
-        }
         browser = MCNearbyServiceBrowser(peer: self.peerID, serviceType: self.serviceType)
         browser.delegate = self
+        
+        isInitialized = true
         
         NotificationCenter.default.addObserver(self, selector: #selector(handleViewWillEnterForeground), name: .DJYusakuRequestVCWillEnterForeground, object: nil)
     }
     
     @objc func handleViewWillEnterForeground() {
-        guard connectedDJ != nil else { return }
-        ConnectionController.shared.browser.invitePeer(connectedDJ, to: ConnectionController.shared.session, withContext: nil, timeout: 10.0)
-    }
-    
-    func startAdvertise() {
-        advertiser.startAdvertisingPeer()
-    }
-    
-    func stopAdvertise() {
-        advertiser.stopAdvertisingPeer()
+        guard let connectedDJ = connectedDJ else { return }
+        browser.invitePeer(connectedDJ, to: ConnectionController.shared.session, withContext: nil, timeout: 10.0)
     }
 
     func startBrowse() {
@@ -79,6 +65,42 @@ class ConnectionController: NSObject {
     
     func stopBrowse() {
         browser.stopBrowsingForPeers()
+    }
+    
+    func disconnect() {
+        session.disconnect()
+        connectedDJ = nil
+        
+    }
+    
+    func startDJ(displayName: String, iconUrlString: String? = nil) {
+        disconnect()
+        var info = ["name": displayName]
+        
+        if iconUrlString != nil {
+            info["imageUrl"] = iconUrlString
+        }
+        
+        advertiser = MCNearbyServiceAdvertiser(peer: self.peerID, discoveryInfo: info, serviceType: self.serviceType)
+        advertiser.delegate = self
+        
+        isDJ = true
+        advertiser.startAdvertisingPeer()
+        if browser != nil {
+            browser.stopBrowsingForPeers()
+        }
+    }
+    
+    func startListener(selectedDJ: MCPeerID) {
+        disconnect()
+        browser.invitePeer(selectedDJ, to: session, withContext: nil, timeout: 10.0)
+        
+        connectedDJ = selectedDJ
+        connectableDJs.removeAll()
+        isDJ = false
+        if advertiser != nil {
+            advertiser.stopAdvertisingPeer()
+        }
     }
     
     func setProfile(profile: PeerProfile){
@@ -94,6 +116,9 @@ extension ConnectionController: MCSessionDelegate {
         switch state {
         case .notConnected:
             print("Peer \(peerID.displayName) is not connected.")
+            if !ConnectionController.shared.isDJ! && peerID == connectedDJ {
+                disconnect()
+            }
             break
         case .connecting:
             print("Peer \(peerID.displayName) is connecting...")
@@ -109,7 +134,7 @@ extension ConnectionController: MCSessionDelegate {
             }
             
             print("Peer \(peerID.displayName) is connected.")
-            if ConnectionController.shared.isDJ {   // DJが新しい子機と接続したとき
+            if ConnectionController.shared.isDJ! {   // DJが新しい子機と接続したとき
                 var songs: [Song] = []
                 for i in 0..<PlayerQueue.shared.count() {
                     songs.append(PlayerQueue.shared.get(at: i)!)
@@ -136,7 +161,7 @@ extension ConnectionController: MCSessionDelegate {
         print("\(peerID)から \(String(data: data, encoding: .utf8)!)を受け取りました")
         
         let messageData = try! JSONDecoder().decode(MessageData.self, from: data)
-        if ConnectionController.shared.isDJ { // DJがデータを受け取ったとき
+        if ConnectionController.shared.isDJ! { // DJがデータを受け取ったとき
             switch messageData.desc {
             case MessageData.DataType.requestSong:
                 let song = try! JSONDecoder().decode(Song.self, from: messageData.value)
@@ -202,7 +227,14 @@ extension ConnectionController: MCNearbyServiceBrowserDelegate {
     // 接続可能なピアが見つかったとき
     public func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String: String]?) {
         self.connectableDJs.append(peerID)
-            
+        
+        // TODO: DJ名にinfoを使うのは非互換な変更のため、以下のようにして互換性を保つ
+        if let info = info {
+            self.connectableDJNameCorrespondence[peerID] = (info["name"], info["imageUrl"]) as? (String, String?)
+        } else {
+            self.connectableDJNameCorrespondence[peerID] = (peerID.displayName, nil)
+        }
+
         self.delegate?.connectionController(didChangeConnectableDevices: self.connectableDJs)
     }
 

--- a/DJYusaku/ConnectionControllerDelegate.swift
+++ b/DJYusaku/ConnectionControllerDelegate.swift
@@ -10,9 +10,6 @@ import Foundation
 import MultipeerConnectivity
 
 protocol ConnectionControllerDelegate: class {
-    // データを受け取ったとき
-    func connectionController(didReceiveData data: Data, from peerID: MCPeerID)
-
     // 接続可能なピアが見つかったとき
     func connectionController(didChangeConnectableDevices devices: [MCPeerID])
 }

--- a/DJYusaku/ListenerConnectableDJsTableViewCell.swift
+++ b/DJYusaku/ListenerConnectableDJsTableViewCell.swift
@@ -11,10 +11,14 @@ import UIKit
 class ListenerConnectableDJsTableViewCell: UITableViewCell {
 
     @IBOutlet weak var djName: UILabel!
+    @IBOutlet weak var djImageView: UIImageView!
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
+        
+        // アイコン画像を円形にする
+        djImageView.layer.cornerRadius = djImageView.frame.size.height * 0.5
+        djImageView.clipsToBounds = true
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/DJYusaku/ListenerConnectionViewController.swift
+++ b/DJYusaku/ListenerConnectionViewController.swift
@@ -71,10 +71,6 @@ extension ListenerConnectionViewController: UITableViewDelegate {
 // MARK: - ConnectionControllerDelegate
 
 extension ListenerConnectionViewController: ConnectionControllerDelegate {
-    func connectionController(didReceiveData data: Data, from peerID: MCPeerID) {
-        
-    }
-
     func connectionController(didChangeConnectableDevices devices: [MCPeerID]) {
         // browserがピアを見つけたらリロード
         DispatchQueue.main.async {

--- a/DJYusaku/ListenerConnectionViewController.swift
+++ b/DJYusaku/ListenerConnectionViewController.swift
@@ -16,25 +16,20 @@ class ListenerConnectionViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        ConnectionController.shared.initialize(isDJ: false, displayName: UIDevice.current.name)
-        ConnectionController.shared.delegate = self
         ConnectionController.shared.startBrowse()
+        ConnectionController.shared.delegate = self
         
         // tableViewのdelegate, dataSource設定
         tableView.delegate = self
         tableView.dataSource = self
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        ConnectionController.shared.stopBrowse()
+        ConnectionController.shared.connectableDJs.removeAll()
     }
-    */
 
 }
 
@@ -47,25 +42,28 @@ extension ListenerConnectionViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "ListenerConnectableDJsTableViewCell", for: indexPath) as! ListenerConnectableDJsTableViewCell
-        let item = ConnectionController.shared.connectableDJs[indexPath.row]
-        cell.djName?.text = "DJ: " + item.displayName
+        let peerID = ConnectionController.shared.connectableDJs[indexPath.row]
+        let (displayName, imageUrlString) = ConnectionController.shared.connectableDJNameCorrespondence[peerID]!
+        cell.djName?.text = displayName
+        if imageUrlString != nil {
+            if let imageUrl = URL(string: imageUrlString!) {
+                cell.djImageView.image = Artwork.fetch(url: imageUrl)
+            }
+        }
 
         return cell
-    }
-    
-     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let selectedDJ = ConnectionController.shared.connectableDJs[indexPath.row]
-        ConnectionController.shared.browser.invitePeer(selectedDJ, to: ConnectionController.shared.session, withContext: nil, timeout: 10.0)
-        ConnectionController.shared.connectedDJ = selectedDJ
-        ConnectionController.shared.stopBrowse()
-        self.dismiss(animated: true, completion: nil)
     }
 }
 
 // MARK: - UITableViewDelegate
 
 extension ListenerConnectionViewController: UITableViewDelegate {
-    /* TODO: 未実装 */
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let selected = ConnectionController.shared.connectableDJs[indexPath.row]
+        ConnectionController.shared.startListener(selectedDJ: selected)
+        
+        self.dismiss(animated: true, completion: nil)
+    }
 }
 
 // MARK: - ConnectionControllerDelegate

--- a/DJYusaku/MemberViewController.swift
+++ b/DJYusaku/MemberViewController.swift
@@ -96,7 +96,8 @@ extension MemberViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell  = tableView.dequeueReusableCell(withIdentifier: "MemberTableViewCell", for: indexPath) as! MemberTableViewCell
-        cell.peerName.text = listeners[indexPath.row].displayName
+        cell.peerName.text       = listeners[indexPath.row].displayName
+        cell.peerImageView.image = nil
         
         // プロフィールが設定されている場合
         DispatchQueue.global().async {

--- a/DJYusaku/MemberViewController.swift
+++ b/DJYusaku/MemberViewController.swift
@@ -48,35 +48,40 @@ class MemberViewController: UIViewController {
     }
     
     func updateMembers() {
-        var DJName = ConnectionController.shared.isDJ
+        var DJName = ConnectionController.shared.isDJ!
                    ? ConnectionController.shared.peerID.displayName
-                   : ConnectionController.shared.connectedDJ.displayName
-        var DJIcon: UIImage?
+                   : ConnectionController.shared.connectedDJ?.displayName
+        var DJIcon: UIImage? = nil
         
-        // 接続している端末（親機）はtableViewには表示しない
-        listeners = ConnectionController.shared.session.connectedPeers.filter({ $0 != ConnectionController.shared.connectedDJ })
+        listeners = ConnectionController.shared.session.connectedPeers
         
-        // 子機のときは自分を先頭に挿入
-        if !ConnectionController.shared.isDJ {
+        if !ConnectionController.shared.isDJ! {
+            if let connectedDJ = ConnectionController.shared.connectedDJ {
+                // 接続している端末（親機）はtableViewには表示しない
+                self.listeners = self.listeners.filter({ $0 != connectedDJ })
+            }
+            // 子機のときは自分を先頭に挿入
             self.listeners.insert(ConnectionController.shared.peerID, at: 0)
         }
         
-        if ConnectionController.shared.isDJ {
+        if ConnectionController.shared.isDJ! {
             if let profile = ConnectionController.shared.profile {
                 DJName = profile.name
                 DJIcon = Artwork.fetch(url: profile.imageUrl)
             }
         } else {
-            if let profile = ConnectionController.shared.peerProfileCorrespondence[ ConnectionController.shared.connectedDJ] {
-                DJName = profile.name
-                DJIcon = Artwork.fetch(url: profile.imageUrl)
+            if let connectedDJ = ConnectionController.shared.connectedDJ {
+                if let profile = ConnectionController.shared.peerProfileCorrespondence[connectedDJ] {
+                    DJName = profile.name
+                    DJIcon = Artwork.fetch(url: profile.imageUrl)
+                }
             }
         }
         
         // 親機の表示を更新
         DispatchQueue.main.async{
             self.DJNameLabel.text  = DJName
-            self.DJImageView.image = DJIcon ?? self.DJImageView.image
+            self.DJImageView.image = DJIcon
             self.tableView.reloadData()
         }
     }
@@ -103,7 +108,7 @@ extension MemberViewController: UITableViewDataSource {
         DispatchQueue.global().async {
             var listenerName: String?
             var listenerIcon: UIImage?
-            if indexPath.row == 0 && !ConnectionController.shared.isDJ { // 自分自身（子機）
+            if indexPath.row == 0 && !ConnectionController.shared.isDJ! { // 自分自身（子機）
                 if let profile = ConnectionController.shared.profile {
                     listenerName = profile.name
                     listenerIcon = Artwork.fetch(url: profile.imageUrl)

--- a/DJYusaku/PlayerQueue.swift
+++ b/DJYusaku/PlayerQueue.swift
@@ -23,7 +23,7 @@ class PlayerQueue{
     
     private var items: [MPMediaItem] = [] {
         didSet {
-            if ConnectionController.shared.isDJ {   // DJのリクエストが更新されたとき
+            if ConnectionController.shared.isDJ! {   // DJのリクエストが更新されたとき
                 guard ConnectionController.shared.session.connectedPeers.count != 0 else { return }
                 var songs: [Song] = []
                 for i in 0..<PlayerQueue.shared.count() {

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -131,7 +131,7 @@ class RequestsViewController: UIViewController {
     
     @objc func handleViewWillEnterForeground() {
         guard ConnectionController.shared.isDJ != nil else { return }
-        if !ConnectionController.shared.isDJ {
+        if !ConnectionController.shared.isDJ! {
             NotificationCenter.default.post(
                 name: .DJYusakuRequestVCWillEnterForeground,
                 object: nil
@@ -142,12 +142,12 @@ class RequestsViewController: UIViewController {
     func scrollToNowPlayingItem(animated: Bool = true) {
         guard ConnectionController.shared.isDJ != nil else { return }
         
-        let numberOfRequestedSongs = ConnectionController.shared.isDJ
+        let numberOfRequestedSongs = ConnectionController.shared.isDJ!
                                    ? PlayerQueue.shared.count()
                                    : ConnectionController.shared.receivedSongs.count
         guard numberOfRequestedSongs != 0 else { return }
         
-        let indexOfNowPlayingItem  = ConnectionController.shared.isDJ
+        let indexOfNowPlayingItem  = ConnectionController.shared.isDJ!
                                    ? PlayerQueue.shared.mpAppController.indexOfNowPlayingItem
                                    : RequestsViewController.self.indexOfNowPlayingItemOnListener
         DispatchQueue.main.async {
@@ -230,7 +230,7 @@ extension RequestsViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         guard ConnectionController.shared.isDJ != nil else { return 0 }
-        if ConnectionController.shared.isDJ {
+        if ConnectionController.shared.isDJ! {
             return PlayerQueue.shared.count()
         } else {
             return ConnectionController.shared.receivedSongs.count
@@ -240,14 +240,14 @@ extension RequestsViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "RequestsMusicTableViewCell", for: indexPath) as! RequestsMusicTableViewCell
         var song: Song
-        if ConnectionController.shared.isDJ {
+        if ConnectionController.shared.isDJ! {
             guard let queueSong = PlayerQueue.shared.get(at: indexPath.row) else { return cell }
             song = queueSong
         } else {
             song = ConnectionController.shared.receivedSongs[indexPath.row]
         }
         
-        let indexOfNowPlayingItem = ConnectionController.shared.isDJ
+        let indexOfNowPlayingItem = ConnectionController.shared.isDJ!
                                   ? PlayerQueue.shared.mpAppController.indexOfNowPlayingItem
                                   : RequestsViewController.self.indexOfNowPlayingItemOnListener
         cell.title.text    = song.title
@@ -289,7 +289,7 @@ extension RequestsViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         self.tableView.deselectRow(at: indexPath, animated: false)  // セルの選択を解除
-        if ConnectionController.shared.isDJ {   // 自分がDJのとき
+        if ConnectionController.shared.isDJ! {   // 自分がDJのとき
             // 曲を再生する
             PlayerQueue.shared.play(at: indexPath.row)
         }

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -92,7 +92,7 @@ extension SearchViewController: UITableViewDelegate {
         
         let song = results[indexPath.row]
         let viewController = self.presentingViewController ?? self   // 閉じる対象のViewController
-        if ConnectionController.shared.isDJ {   // 自分がDJのとき
+        if ConnectionController.shared.isDJ! {   // 自分がDJのとき
             PlayerQueue.shared.add(with: song) { [unowned viewController] in
                 viewController.dismiss(animated: true)    // 1曲追加するごとにViewを閉じる
             }
@@ -101,8 +101,10 @@ extension SearchViewController: UITableViewDelegate {
             
             let messageData = try! JSONEncoder().encode(MessageData(desc:  MessageData.DataType.requestSong, value: songData))
             
-            ConnectionController.shared.session.sendRequest(messageData, toPeers: [ConnectionController.shared.connectedDJ], with: .unreliable) { [unowned viewController] in
+            if let connectedDJ = ConnectionController.shared.connectedDJ {
+                ConnectionController.shared.session.sendRequest(messageData, toPeers: [connectedDJ], with: .unreliable) { [unowned viewController] in
                 viewController.dismiss(animated: true)    // 1曲追加するごとにViewを閉じる
+                }
             }
         }
     }

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -97,14 +97,13 @@ extension SearchViewController: UITableViewDelegate {
                 viewController.dismiss(animated: true)    // 1曲追加するごとにViewを閉じる
             }
         } else {                                    // 自分がリスナーのとき
+            guard let connectedDJ = ConnectionController.shared.connectedDJ else { return }
             let songData = try! JSONEncoder().encode(song)
             
             let messageData = try! JSONEncoder().encode(MessageData(desc:  MessageData.DataType.requestSong, value: songData))
             
-            if let connectedDJ = ConnectionController.shared.connectedDJ {
-                ConnectionController.shared.session.sendRequest(messageData, toPeers: [connectedDJ], with: .unreliable) { [unowned viewController] in
+            ConnectionController.shared.session.sendRequest(messageData, toPeers: [connectedDJ], with: .unreliable) { [unowned viewController] in
                 viewController.dismiss(animated: true)    // 1曲追加するごとにViewを閉じる
-                }
             }
         }
     }

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -17,33 +17,32 @@ class WelcomeViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        if !ConnectionController.shared.isInitialized {
+            ConnectionController.shared.initialize()
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        self.doneButtonItem.isEnabled = WelcomeViewController.isViewAppearedAtLeastOnce
-        WelcomeViewController.isViewAppearedAtLeastOnce = true
+        if let _ = ConnectionController.shared.isDJ {
+            self.doneButtonItem.isEnabled = true
+        } else {
+            self.doneButtonItem.isEnabled = false
+        }
     }
-    
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
 
     @IBAction func closeModal(_ sender: Any) {
         self.dismiss(animated: true, completion: nil)
     }
     
     @IBAction func joinAsDJ(_ sender: Any) {
-        ConnectionController.shared.initialize(isDJ: true, displayName: UIDevice.current.name)
-        
-        ConnectionController.shared.startAdvertise()
+        if let profile = ConnectionController.shared.profile {
+            ConnectionController.shared.startDJ(displayName: profile.name, iconUrlString: profile.imageUrl.absoluteString)
+        } else {
+            ConnectionController.shared.startDJ(displayName: UIDevice.current.name)
+        }
         
         self.dismiss(animated: true, completion: nil)
     }

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -26,7 +26,7 @@ class WelcomeViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        if let _ = ConnectionController.shared.isDJ {
+        if ConnectionController.shared.isDJ != nil {
             self.doneButtonItem.isEnabled = true
         } else {
             self.doneButtonItem.isEnabled = false


### PR DESCRIPTION
### やったこと
いっぱいやりました。
#### バグ修正
* 起動直後のWelcome Sceneで、[join as a Listener] ボタンを押して[Back]で戻るとDoneが押せてしまう不具合を修正（これによってDJでもリスナでもない状態になってしまうことがなくなる）
* DJとして参加し、[Reconnect]を押し、[join as a Listener] ボタンを押したが「やっぱやめた（DJを選ばずにViewを閉じる）」したとき、リスナになってしまっている不具合を修正（DJがリスナに切り替わるのはJoin as a Listener Sceneを表示した時ではなく、実際にDJをタップしたときになった）
-> join as a Listenerというボタンの名前は適切か？（正確には「周囲にいるDJを見る」機能）
* Sessionタブの子機一覧で、twitter連携してない子機のアイコンに他の人のアイコンが表示されてしまう不具合を修正 280052d
* リスナが別のDJに繋いだとき、Sessionタブの親機のアイコンに以前繋がっていたDJのアイコンが表示されてしまう不具合を修正

#### 新機能
* Join as a Listener Sceneを改良
  * 「DJ: 端末名」という味気ないものから、アイコンと名前を表示するようにした（アイコンはtwitterのものに対応）

### 技術的な話
* isDJをBool!型からBool?型にする
isDJがnilのときWelcome Sceneを閉じられないようにした。

* connectedDJをMCPeerID!型からMCPeerID?型にする
リスナ視点で、接続中の親機がいないとき（つまり、親機を見失ったとき）connectedDJにnilが入る。

* initializeはアプリ内で一回だけ呼ぶ
今まで[join as the DJ] ボタンを押したときと[join as a Listener]ボタンを押したときでinitializeし直していた(sessionを作り直していた）。よく考えるとその必要はない（session.disconnect()すればいい）ので、initializeはアプリ内で一度だけ呼ばれるようにする。

* browserがBrowsingしてるのはJoin as a Listener Sceneにいるときだけ
viewWillDisappearメソッドを使ってJoin as a Listener Sceneを離れるとき（DJを選択したときか[Back]を押したとき）にbrowseを止める（connectableDJs.removeAll()もする）。

### やってほしいこと

実機で試してみて、なんかバグが発生しないか。コードにアレなところないか。