### PR TITLE
Twitterのログイン状態を保存・復元

### DIFF
--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -39,7 +39,8 @@
 		C4CF9725235163EF00C8A102 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4CF9724235163EF00C8A102 /* SearchViewController.swift */; };
 		C4D25958235205D10066FCE0 /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D25957235205D10066FCE0 /* Secrets.swift */; };
 		C4D2595A235205EC0066FCE0 /* Secrets+Local.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D25959235205EC0066FCE0 /* Secrets+Local.swift */; };
-		C4E5CD8823AB8A2700C0807A /* PeerProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E5CD8723AB8A2700C0807A /* PeerProfile.swift */; };
+		C4D9018B23AF3ED40068F5C0 /* DefaultsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D9018A23AF3ED40068F5C0 /* DefaultsController.swift */; };
+		C4D9018D23AF4BA30068F5C0 /* PeerProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D9018C23AF4BA30068F5C0 /* PeerProfile.swift */; };
 		C4FDD0CC2356EA8F007569B1 /* RequestsMusicTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FDD0CB2356EA8F007569B1 /* RequestsMusicTableViewCell.swift */; };
 /* End PBXBuildFile section */
 
@@ -96,7 +97,8 @@
 		C4CF9724235163EF00C8A102 /* SearchViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		C4D25957235205D10066FCE0 /* Secrets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secrets.swift; sourceTree = "<group>"; };
 		C4D25959235205EC0066FCE0 /* Secrets+Local.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Secrets+Local.swift"; sourceTree = "<group>"; };
-		C4E5CD8723AB8A2700C0807A /* PeerProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerProfile.swift; sourceTree = "<group>"; };
+		C4D9018A23AF3ED40068F5C0 /* DefaultsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultsController.swift; sourceTree = "<group>"; };
+		C4D9018C23AF4BA30068F5C0 /* PeerProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerProfile.swift; sourceTree = "<group>"; };
 		C4FDD0CB2356EA8F007569B1 /* RequestsMusicTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestsMusicTableViewCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -165,6 +167,7 @@
 				C46CE2072383EBC000492AC3 /* BatterySaverViewController.swift */,
 				106B1C2E2372C696008684EB /* ConnectionController.swift */,
 				106B1C302372C83F008684EB /* ConnectionControllerDelegate.swift */,
+				C4D9018A23AF3ED40068F5C0 /* DefaultsController.swift */,
 				C43634D223923485000CE58F /* DummyViewController.swift */,
 				106B1C2C2372BE1F008684EB /* ListenerConnectableDJsTableViewCell.swift */,
 				106B1C2A2372BCA8008684EB /* ListenerConnectionViewController.swift */,
@@ -172,7 +175,7 @@
 				418177812388EEF300A7B02A /* MemberTableViewCell.swift */,
 				4181777B2388DC5E00A7B02A /* MemberViewController.swift */,
 				1049BAF723877093001DCFD8 /* MessageData.swift */,
-				C4E5CD8723AB8A2700C0807A /* PeerProfile.swift */,
+				C4D9018C23AF4BA30068F5C0 /* PeerProfile.swift */,
 				411F288A23616EEB00BA96C1 /* PlayerQueue.swift */,
 				C4FDD0CB2356EA8F007569B1 /* RequestsMusicTableViewCell.swift */,
 				C447ACA9234882F900D535EB /* RequestsViewController.swift */,
@@ -184,11 +187,11 @@
 				10937F5B23A9DB4F00CB819B /* SettingViewController.swift */,
 				C436A8552350B16B009F6498 /* Song.swift */,
 				C43634CD23922708000CE58F /* TabBarController.swift */,
+				C41F18E223AE03BE00E1A886 /* UserDefaults+DJYusakuDefaults.swift */,
 				C40DC87F236570DD00E80AB1 /* WelcomeViewController.swift */,
 				C447ACB0234882FB00D535EB /* Assets.xcassets */,
 				C447ACB2234882FB00D535EB /* LaunchScreen.storyboard */,
 				C447ACAD234882F900D535EB /* Main.storyboard */,
-				C41F18E223AE03BE00E1A886 /* UserDefaults+DJYusakuDefaults.swift */,
 			);
 			path = DJYusaku;
 			sourceTree = "<group>";
@@ -362,6 +365,8 @@
 				1049BAF823877093001DCFD8 /* MessageData.swift in Sources */,
 				411F288B23616EEB00BA96C1 /* PlayerQueue.swift in Sources */,
 				C4FDD0CC2356EA8F007569B1 /* RequestsMusicTableViewCell.swift in Sources */,
+				C4D9018B23AF3ED40068F5C0 /* DefaultsController.swift in Sources */,
+				C4D9018D23AF4BA30068F5C0 /* PeerProfile.swift in Sources */,
 				C436A8562350B16B009F6498 /* Song.swift in Sources */,
 				C4D25958235205D10066FCE0 /* Secrets.swift in Sources */,
 				10937F5C23A9DB4F00CB819B /* SettingViewController.swift in Sources */,
@@ -371,7 +376,6 @@
 				C43634CE23922708000CE58F /* TabBarController.swift in Sources */,
 				106B1C2B2372BCA8008684EB /* ListenerConnectionViewController.swift in Sources */,
 				C4D2595A235205EC0066FCE0 /* Secrets+Local.swift in Sources */,
-				C4E5CD8823AB8A2700C0807A /* PeerProfile.swift in Sources */,
 				B10A9E122373F46E00209871 /* MCSession+sendRequest.swift in Sources */,
 				418177822388EEF300A7B02A /* MemberTableViewCell.swift in Sources */,
 				106B1C312372C83F008684EB /* ConnectionControllerDelegate.swift in Sources */,

--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		B10A9E122373F46E00209871 /* MCSession+sendRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10A9E112373F46E00209871 /* MCSession+sendRequest.swift */; };
 		B125D88D235F426C00D383E7 /* Artwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = B125D88C235F426C00D383E7 /* Artwork.swift */; };
 		C40DC880236570DD00E80AB1 /* WelcomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40DC87F236570DD00E80AB1 /* WelcomeViewController.swift */; };
+		C41F18E323AE03BE00E1A886 /* UserDefaults+DJYusakuDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = C41F18E223AE03BE00E1A886 /* UserDefaults+DJYusakuDefaults.swift */; };
 		C43634CE23922708000CE58F /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C43634CD23922708000CE58F /* TabBarController.swift */; };
 		C43634D1239227F6000CE58F /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = C43634D0239227F6000CE58F /* SnapKit */; };
 		C43634D323923485000CE58F /* DummyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C43634D223923485000CE58F /* DummyViewController.swift */; };
@@ -72,6 +73,7 @@
 		B10A9E112373F46E00209871 /* MCSession+sendRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MCSession+sendRequest.swift"; sourceTree = "<group>"; };
 		B125D88C235F426C00D383E7 /* Artwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artwork.swift; sourceTree = "<group>"; };
 		C40DC87F236570DD00E80AB1 /* WelcomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeViewController.swift; sourceTree = "<group>"; };
+		C41F18E223AE03BE00E1A886 /* UserDefaults+DJYusakuDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+DJYusakuDefaults.swift"; sourceTree = "<group>"; };
 		C43634CD23922708000CE58F /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		C43634D223923485000CE58F /* DummyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyViewController.swift; sourceTree = "<group>"; };
 		C436A8552350B16B009F6498 /* Song.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Song.swift; sourceTree = "<group>"; };
@@ -186,6 +188,7 @@
 				C447ACB0234882FB00D535EB /* Assets.xcassets */,
 				C447ACB2234882FB00D535EB /* LaunchScreen.storyboard */,
 				C447ACAD234882F900D535EB /* Main.storyboard */,
+				C41F18E223AE03BE00E1A886 /* UserDefaults+DJYusakuDefaults.swift */,
 			);
 			path = DJYusaku;
 			sourceTree = "<group>";
@@ -353,6 +356,7 @@
 				B125D88D235F426C00D383E7 /* Artwork.swift in Sources */,
 				C4CF9725235163EF00C8A102 /* SearchViewController.swift in Sources */,
 				4181777C2388DC5E00A7B02A /* MemberViewController.swift in Sources */,
+				C41F18E323AE03BE00E1A886 /* UserDefaults+DJYusakuDefaults.swift in Sources */,
 				106B1C2D2372BE1F008684EB /* ListenerConnectableDJsTableViewCell.swift in Sources */,
 				C43634D323923485000CE58F /* DummyViewController.swift in Sources */,
 				1049BAF823877093001DCFD8 /* MessageData.swift in Sources */,

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -39,7 +39,6 @@ class ConnectionController: NSObject {
     
     var receivedSongs: [Song] = []
     
-    var profile: PeerProfile? = nil
     var peerProfileCorrespondence: [MCPeerID:PeerProfile] = [:]
     
     func initialize() {
@@ -100,9 +99,6 @@ class ConnectionController: NSObject {
         }
     }
     
-    func setProfile(profile: PeerProfile){
-        self.profile = profile
-    }
 }
 
 // MARK: - MCSessionDelegate
@@ -124,7 +120,7 @@ extension ConnectionController: MCSessionDelegate {
             NotificationCenter.default.post(name: .DJYusakuPeerConnectionStateDidUpdate, object: nil)
             
             // プロフィールが設定されていれば他のピアに送信する
-            if let profile = self.profile {
+            if let profile = DefaultsController.shared.profile {
                 let data = try! JSONEncoder().encode(profile)
                 let messageData = try! JSONEncoder().encode(MessageData(desc:  MessageData.DataType.peerProfile, value: data))
                 ConnectionController.shared.session.sendRequest(messageData, toPeers: [peerID], with: .unreliable)

--- a/DJYusaku/DefaultsController.swift
+++ b/DJYusaku/DefaultsController.swift
@@ -1,0 +1,75 @@
+//
+//  DefaultsController.swift
+//  DJYusaku
+//
+//  Created by Hayato Kohara on 2019/12/22.
+//  Copyright © 2019 Yusaku. All rights reserved.
+//
+
+import UIKit
+import Swifter
+
+struct TwitterAccount {
+    var key:        String
+    var secret:     String
+    var screenName: String
+    
+    init(key: String, secret: String, screenName: String) {
+        self.key        = key
+        self.secret     = secret
+        self.screenName = screenName
+    }
+}
+
+class DefaultsController: NSObject {
+    static let shared = DefaultsController()
+    
+    public private(set) var twitterAccount: TwitterAccount? = nil
+    public private(set) var swifter : Swifter = Swifter(consumerKey: Secrets.TwitterConsumerKey,
+                                                        consumerSecret: Secrets.TwitterConsumerSecret)
+    
+    public private(set) var profile: PeerProfile? = nil
+    
+    private override init() {
+        super.init()
+        
+        // ログイン状態が保存されていればプロフィールを取得する
+        self.setupTwitterAccount()
+        self.setProfileFromTwitter()
+    }
+
+    func setupTwitterAccount() {
+        if let twitterKey        = UserDefaults.standard.string(forKey: UserDefaults.DJYusakuDefaults.TwitterKey)
+         , let twitterSecret     = UserDefaults.standard.string(forKey: UserDefaults.DJYusakuDefaults.TwitterSecret)
+         , let twitterScreenName = UserDefaults.standard.string(forKey: UserDefaults.DJYusakuDefaults.TwitterScreenName) {
+            self.twitterAccount = TwitterAccount(key: twitterKey, secret: twitterSecret, screenName: twitterScreenName)
+            self.swifter = Swifter(consumerKey:      Secrets.TwitterConsumerKey,
+                                   consumerSecret:   Secrets.TwitterConsumerSecret,
+                                   oauthToken:       self.twitterAccount!.key,
+                                   oauthTokenSecret: self.twitterAccount!.secret)
+        }
+    }
+    
+    func setProfileFromTwitter(currentViewController: UIViewController? = nil,
+                               completion: (() -> (Void))? = nil) {
+        guard let twitterAccount = self.twitterAccount else { return }
+        // ユーザーのプロフィール情報を取得して設定する
+        self.swifter.showUser(.screenName(twitterAccount.screenName), success: { json in
+            let imageUrlString = json["profile_image_url_https"].string!.replacingOccurrences(of: "_normal", with: "", options: .backwards)
+            self.profile = PeerProfile(name: json["name"].string!,
+                                       imageUrl: URL(string: imageUrlString)!)
+            if let completion = completion { completion() }
+        }, failure: { error in
+            guard let viewController = currentViewController else {
+                print(error.localizedDescription)
+                return
+            }
+            let alert = UIAlertController(title: "Error",
+                                          message: error.localizedDescription,
+                                          preferredStyle: UIAlertController.Style.alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+            viewController.present(alert, animated: true)
+        })
+    }
+    
+}

--- a/DJYusaku/MemberViewController.swift
+++ b/DJYusaku/MemberViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Swifter
 import MultipeerConnectivity
 
 class MemberViewController: UIViewController {
@@ -32,7 +33,7 @@ class MemberViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+
         self.updateMembers()
     }
     
@@ -65,7 +66,7 @@ class MemberViewController: UIViewController {
         }
         
         if ConnectionController.shared.isDJ! {
-            if let profile = ConnectionController.shared.profile {
+            if let profile = DefaultsController.shared.profile {
                 DJName = profile.name
                 DJIcon = Artwork.fetch(url: profile.imageUrl)
             }
@@ -109,7 +110,7 @@ extension MemberViewController: UITableViewDataSource {
             var listenerName: String?
             var listenerIcon: UIImage?
             if indexPath.row == 0 && !ConnectionController.shared.isDJ! { // 自分自身（子機）
-                if let profile = ConnectionController.shared.profile {
+                if let profile = DefaultsController.shared.profile {
                     listenerName = profile.name
                     listenerIcon = Artwork.fetch(url: profile.imageUrl)
                     DispatchQueue.main.async {

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -178,7 +178,7 @@ extension SearchViewController: UISearchResultsUpdating {
                     let artworkUrlString = song["attributes"]["artwork"]["url"].stringValue
                     let songID           = song["attributes"]["playParams"]["id"].stringValue
                     let artworkUrl = Artwork.url(urlString: artworkUrlString, width: 256, height: 256)
-                    self.results.append(Song(title: title, artist: artist, artworkUrl: artworkUrl, id: songID, profileImageUrl: ConnectionController.shared.profile?.imageUrl))
+                    self.results.append(Song(title: title, artist: artist, artworkUrl: artworkUrl, id: songID, profileImageUrl: DefaultsController.shared.profile?.imageUrl))
                 }
                 self.tableView.reloadData()
             }

--- a/DJYusaku/SettingViewController.swift
+++ b/DJYusaku/SettingViewController.swift
@@ -11,37 +11,54 @@ import Swifter
 import SafariServices
 
 class SettingViewController: UIViewController, SFSafariViewControllerDelegate {
-    private var swifter = Swifter(
-        consumerKey: Secrets.TwitterConsumerKey,
-        consumerSecret: Secrets.TwitterConsumerSecret
-    )
-    
-    private var screenName: String?
+    private var swifter : Swifter = Swifter(consumerKey: Secrets.TwitterConsumerKey,
+                                            consumerSecret: Secrets.TwitterConsumerSecret)
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        // ログイン状態が保存されていればプロフィールを取得する
+        if let twitterKey        = UserDefaults.standard.string(forKey: UserDefaults.DJYusakuDefaults.TwitterKey)
+         , let twitterSecret     = UserDefaults.standard.string(forKey: UserDefaults.DJYusakuDefaults.TwitterSecret)
+         , let twitterScreenName = UserDefaults.standard.string(forKey: UserDefaults.DJYusakuDefaults.TwitterScreenName) {
+            swifter = Swifter(consumerKey: Secrets.TwitterConsumerKey,
+                              consumerSecret: Secrets.TwitterConsumerSecret,
+                              oauthToken: twitterKey,
+                              oauthTokenSecret: twitterSecret)
+            // プロフィールを取得する
+            print(twitterScreenName)
+            self.getProfile(screenName: twitterScreenName)
+        }
     }
     
     @IBAction func loginTwitter(_ sender: Any) {
         let url = URL(string: "swifter://success")!
         swifter.authorize(withCallback: url, presentingFrom: self, success: { [unowned self] token, _ in
-            if token != nil {
-                self.screenName = token!.screenName
-            }
-            // ユーザーのプロフィール情報を取得して設定する
-            self.swifter.showUser(.screenName(self.screenName!), success: { json in
-                let imageUrlString = json["profile_image_url_https"].string!.replacingOccurrences(of: "_normal", with: "", options: .backwards)
-                let profile = PeerProfile(name:     json["name"].string!,
-                                          imageUrl: URL(string: imageUrlString)!)
-                ConnectionController.shared.setProfile(profile: profile)
-                NotificationCenter.default.post(name: .DJYusakuPeerConnectionStateDidUpdate, object: nil)
-                // プロフィールを他のピアに送信する
-                let data = try! JSONEncoder().encode(profile)
-                let messageData = try! JSONEncoder().encode(MessageData(desc:  MessageData.DataType.peerProfile, value: data))
-                ConnectionController.shared.session.sendRequest(messageData, toPeers: ConnectionController.shared.session.connectedPeers, with: .unreliable)
-            }, failure: { error in
-                self.alert(title: "Error", message: error.localizedDescription)
-            })
+            guard token != nil else { return }
+            // ログイン状態を保存する
+            UserDefaults.standard.set(token?.key,         forKey: UserDefaults.DJYusakuDefaults.TwitterKey)
+            UserDefaults.standard.set(token?.secret,      forKey: UserDefaults.DJYusakuDefaults.TwitterSecret)
+            UserDefaults.standard.set(token!.screenName!, forKey: UserDefaults.DJYusakuDefaults.TwitterScreenName)
+
+            self.getProfile(screenName: token!.screenName!)
+        }, failure: { error in
+            self.alert(title: "Error", message: error.localizedDescription)
+        })
+    }
+    
+    func getProfile(screenName: String) {
+        
+        // ユーザーのプロフィール情報を取得して設定する
+        self.swifter.showUser(.screenName(screenName), success: { json in
+            let imageUrlString = json["profile_image_url_https"].string!.replacingOccurrences(of: "_normal", with: "", options: .backwards)
+            let profile = PeerProfile(name:     json["name"].string!,
+                                      imageUrl: URL(string: imageUrlString)!)
+            ConnectionController.shared.setProfile(profile: profile)
+            NotificationCenter.default.post(name: .DJYusakuPeerConnectionStateDidUpdate, object: nil)
+            // プロフィールを他のピアに送信する
+            let data = try! JSONEncoder().encode(profile)
+            let messageData = try! JSONEncoder().encode(MessageData(desc:  MessageData.DataType.peerProfile, value: data))
+            ConnectionController.shared.session.sendRequest(messageData, toPeers: ConnectionController.shared.session.connectedPeers, with: .unreliable)
         }, failure: { error in
             self.alert(title: "Error", message: error.localizedDescription)
         })

--- a/DJYusaku/SettingViewController.swift
+++ b/DJYusaku/SettingViewController.swift
@@ -11,65 +11,36 @@ import Swifter
 import SafariServices
 
 class SettingViewController: UIViewController, SFSafariViewControllerDelegate {
-    private var swifter : Swifter = Swifter(consumerKey: Secrets.TwitterConsumerKey,
-                                            consumerSecret: Secrets.TwitterConsumerSecret)
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        // ログイン状態が保存されていればプロフィールを取得する
-        if let twitterKey        = UserDefaults.standard.string(forKey: UserDefaults.DJYusakuDefaults.TwitterKey)
-         , let twitterSecret     = UserDefaults.standard.string(forKey: UserDefaults.DJYusakuDefaults.TwitterSecret)
-         , let twitterScreenName = UserDefaults.standard.string(forKey: UserDefaults.DJYusakuDefaults.TwitterScreenName) {
-            swifter = Swifter(consumerKey: Secrets.TwitterConsumerKey,
-                              consumerSecret: Secrets.TwitterConsumerSecret,
-                              oauthToken: twitterKey,
-                              oauthTokenSecret: twitterSecret)
-            // プロフィールを取得する
-            print(twitterScreenName)
-            self.getProfile(screenName: twitterScreenName)
-        }
     }
     
     @IBAction func loginTwitter(_ sender: Any) {
         let url = URL(string: "swifter://success")!
-        swifter.authorize(withCallback: url, presentingFrom: self, success: { [unowned self] token, _ in
+        DefaultsController.shared.swifter.authorize(withCallback: url, presentingFrom: self, success: { token, _ in
             guard token != nil else { return }
             // ログイン状態を保存する
             UserDefaults.standard.set(token?.key,         forKey: UserDefaults.DJYusakuDefaults.TwitterKey)
             UserDefaults.standard.set(token?.secret,      forKey: UserDefaults.DJYusakuDefaults.TwitterSecret)
             UserDefaults.standard.set(token!.screenName!, forKey: UserDefaults.DJYusakuDefaults.TwitterScreenName)
-
-            self.getProfile(screenName: token!.screenName!)
+            DefaultsController.shared.setupTwitterAccount()
+            DefaultsController.shared.setProfileFromTwitter(currentViewController: self) {
+                // プロフィールを他のピアに送信する
+                let data = try! JSONEncoder().encode(DefaultsController.shared.profile!)
+                let messageData = try! JSONEncoder().encode(MessageData(desc: MessageData.DataType.peerProfile, value: data))
+                ConnectionController.shared.session.sendRequest(messageData,
+                                                                toPeers: ConnectionController.shared.session.connectedPeers,
+                                                                with: .unreliable)
+                NotificationCenter.default.post(name: .DJYusakuPeerConnectionStateDidUpdate, object: nil)
+            }
         }, failure: { error in
-            self.alert(title: "Error", message: error.localizedDescription)
+            let alert = UIAlertController(title: "Error", message: error.localizedDescription, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+            self.present(alert, animated: true, completion: nil)
         })
     }
     
-    func getProfile(screenName: String) {
-        
-        // ユーザーのプロフィール情報を取得して設定する
-        self.swifter.showUser(.screenName(screenName), success: { json in
-            let imageUrlString = json["profile_image_url_https"].string!.replacingOccurrences(of: "_normal", with: "", options: .backwards)
-            let profile = PeerProfile(name:     json["name"].string!,
-                                      imageUrl: URL(string: imageUrlString)!)
-            ConnectionController.shared.setProfile(profile: profile)
-            NotificationCenter.default.post(name: .DJYusakuPeerConnectionStateDidUpdate, object: nil)
-            // プロフィールを他のピアに送信する
-            let data = try! JSONEncoder().encode(profile)
-            let messageData = try! JSONEncoder().encode(MessageData(desc:  MessageData.DataType.peerProfile, value: data))
-            ConnectionController.shared.session.sendRequest(messageData, toPeers: ConnectionController.shared.session.connectedPeers, with: .unreliable)
-        }, failure: { error in
-            self.alert(title: "Error", message: error.localizedDescription)
-        })
-    }
-    
-    func alert(title: String, message: String) {
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-        self.present(alert, animated: true, completion: nil)
-    }
-
     func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
         controller.dismiss(animated: true, completion: nil)
     }

--- a/DJYusaku/UserDefaults+DJYusakuDefaults.swift
+++ b/DJYusaku/UserDefaults+DJYusakuDefaults.swift
@@ -1,0 +1,20 @@
+//
+//  UserDefaults+DJYusakuDefaults.swift
+//  DJYusaku
+//
+//  Created by Hayato Kohara on 2019/12/21.
+//  Copyright © 2019 Yusaku. All rights reserved.
+//
+
+import UIKit
+
+extension UserDefaults {
+    class DJYusakuDefaults {
+        static let TwitterKey        = "TwitterKey"
+        static let TwitterSecret     = "TwitterSecret"
+        static let TwitterScreenName = "TwitterScreenName"
+        static let ProfileName       = "ProfileName"
+        static let ProfileImageURL   = "ProfileImageURL"
+    }
+    
+}

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -38,7 +38,7 @@ class WelcomeViewController: UIViewController {
     }
     
     @IBAction func joinAsDJ(_ sender: Any) {
-        if let profile = ConnectionController.shared.profile {
+        if let profile = DefaultsController.shared.profile {
             ConnectionController.shared.startDJ(displayName: profile.name, iconUrlString: profile.imageUrl.absoluteString)
         } else {
             ConnectionController.shared.startDJ(displayName: UIDevice.current.name)


### PR DESCRIPTION
### やったこと

- [x] Twitterのログイン状態のUserDefaultsへの保存
- [x] アプリ起動時にUserDefaultsからPeerProfileへの復元
- [x] PeerProfileのDefaultsControllerへの移動
  - Profile情報はUserDefaultsに依存しているため

### やってほしいこと

動作確認

### メモ

- PeerProfileのURLのOptional化を誰かやってくれ
 #75 のconnectableDJNameCorrespondenceとpeerProfileCorrespondenceの一本化