### PR TITLE
DJと接続が切れてもdisconnect()を呼ばない

### DIFF
--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -89,7 +89,9 @@ class ConnectionController: NSObject {
     }
     
     func startListener(selectedDJ: MCPeerID) {
-        disconnect()
+        if selectedDJ != connectedDJ {
+            disconnect()
+        }
         browser.invitePeer(selectedDJ, to: session, withContext: nil, timeout: 10.0)
         
         connectedDJ = selectedDJ
@@ -113,9 +115,6 @@ extension ConnectionController: MCSessionDelegate {
         switch state {
         case .notConnected:
             print("Peer \(peerID.displayName) is not connected.")
-            if !ConnectionController.shared.isDJ! && peerID == connectedDJ {
-                disconnect()
-            }
             break
         case .connecting:
             print("Peer \(peerID.displayName) is connecting...")


### PR DESCRIPTION
再接続機能のこと忘れてました。
DJ見失ってもconnectedDJ = nilしちゃうdisconnect()は呼んではいけないのでした。

また、startListenerメソッドで同じDJに再接続するならdisconnect()しない。
（実は今のmaster、リスナがReconnect押して同じDJに接続するとconnectedDJがnilになってしまうバグがある）