### PR TITLE
profileがセットされたら、そのprofile使って再advertiseする他

### DIFF
--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -851,6 +851,7 @@
                     <connections>
                         <outlet property="DJImageView" destination="KmF-kX-f76" id="oZ7-ES-pcW"/>
                         <outlet property="DJNameLabel" destination="yP3-9N-fvb" id="0H7-1v-B4C"/>
+                        <outlet property="DJStatusLabel" destination="0Zn-fy-Vhb" id="T23-Cp-JjQ"/>
                         <outlet property="tableView" destination="ljm-v3-8g9" id="Wfb-fc-RgC"/>
                     </connections>
                 </viewController>

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -504,9 +504,9 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KK9-dh-Qaa">
-                                                    <rect key="frame" x="64" y="22" width="334" height="20"/>
+                                                    <rect key="frame" x="64" y="17" width="334" height="30"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="height" constant="20" id="7nV-4J-FpJ"/>
+                                                        <constraint firstAttribute="height" constant="30" id="7nV-4J-FpJ"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="21"/>
                                                     <nil key="textColor"/>

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -57,6 +57,7 @@ class ConnectionController: NSObject {
         guard let connectedDJ = self.connectedDJ else { return }
         self.browser.invitePeer(connectedDJ.peerID, to: self.session, withContext: nil, timeout: 10.0)
         self.connectedDJ!.state = .connected
+        NotificationCenter.default.post(name: .DJYusakuPeerConnectionStateDidUpdate, object: nil)
     }
 
     func startBrowse() {
@@ -70,7 +71,7 @@ class ConnectionController: NSObject {
     func disconnect() {
         self.session.disconnect()
         self.connectedDJ = nil
-        
+        NotificationCenter.default.post(name: .DJYusakuPeerConnectionStateDidUpdate, object: nil)
     }
     
     func startDJ() {
@@ -118,6 +119,7 @@ extension ConnectionController: MCSessionDelegate {
             print("Peer \(peerID.displayName) is not connected.")
             if !ConnectionController.shared.isDJ! && peerID == connectedDJ?.peerID {
                 self.connectedDJ!.state = .notConnected
+                NotificationCenter.default.post(name: .DJYusakuPeerConnectionStateDidUpdate, object: nil)
             }
             break
         case .connecting:

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -60,6 +60,17 @@ class ConnectionController: NSObject {
         NotificationCenter.default.post(name: .DJYusakuPeerConnectionStateDidUpdate, object: nil)
     }
 
+    func startAdvertise(displayName: String, imageUrl: URL?) {
+        if self.advertiser != nil {
+            self.advertiser.stopAdvertisingPeer()
+        }
+        let info = ["name":     displayName,
+                    "imageUrl": imageUrl?.absoluteString ?? ""]
+        self.advertiser = MCNearbyServiceAdvertiser(peer: self.peerID, discoveryInfo: info, serviceType: self.serviceType)
+        self.advertiser.delegate = self
+        self.advertiser.startAdvertisingPeer()
+    }
+    
     func startBrowse() {
         self.browser.startBrowsingForPeers()
     }
@@ -76,21 +87,12 @@ class ConnectionController: NSObject {
     
     func startDJ() {
         self.disconnect()
-        
-        var info = ["name":     "",
-                    "imageUrl": ""]
         if let profile = DefaultsController.shared.profile {
-            info["name"] = profile.name
-            info["imageUrl"] = profile.imageUrl?.absoluteString ?? ""
+            startAdvertise(displayName: profile.name, imageUrl: profile.imageUrl)
         } else {
-            info["name"] = UIDevice.current.name
+            startAdvertise(displayName: UIDevice.current.name, imageUrl: nil)
         }
-        
-        self.advertiser = MCNearbyServiceAdvertiser(peer: self.peerID, discoveryInfo: info, serviceType: self.serviceType)
-        self.advertiser.delegate = self
-        
         self.isDJ = true
-        self.advertiser.startAdvertisingPeer()
         NotificationCenter.default.post(name: .DJYusakuUserStateDidUpdate, object: nil)
     }
     

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -32,14 +32,14 @@ class ConnectionController: NSObject {
     private(set) var isInitialized = false
     
     var isDJ: Bool? = nil
-    
-    // Listener 用
-    var connectableDJs: [MCPeerID] = []
     var connectedDJ: (peerID: MCPeerID, state: MCSessionState)? = nil
     
-    var receivedSongs: [Song] = []
-    
     var peerProfileCorrespondence: [MCPeerID:PeerProfile] = [:]
+    
+    var connectableDJs: [MCPeerID] = [] //  ListenerConnectionViewController用
+    
+    var receivedSongs: [Song] = [] // リスナー用
+    
     
     func initialize() {
         self.session = MCSession(peer: self.peerID)
@@ -50,7 +50,13 @@ class ConnectionController: NSObject {
         
         self.isInitialized = true
         
+        NotificationCenter.default.addObserver(self, selector: #selector(handleViewDidEnterBackground), name: .DJYusakuRequestVCDidEnterBackground, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleViewWillEnterForeground), name: .DJYusakuRequestVCWillEnterForeground, object: nil)
+    }
+    
+    @objc func handleViewDidEnterBackground() {
+        guard self.connectedDJ != nil else { return }
+        self.session.disconnect()
     }
     
     @objc func handleViewWillEnterForeground() {

--- a/DJYusaku/DefaultsController.swift
+++ b/DJYusaku/DefaultsController.swift
@@ -74,6 +74,8 @@ class DefaultsController: NSObject {
     // プロフィールを他のピアに送信する
     private func sendProfile() {
         if let profile = self.profile {
+            ConnectionController.shared.startAdvertise(displayName: profile.name, imageUrl: profile.imageUrl)
+            
             let data = try! JSONEncoder().encode(profile)
             let messageData = try! JSONEncoder().encode(MessageData(desc: MessageData.DataType.peerProfile, value: data))
             ConnectionController.shared.session.sendRequest(messageData,

--- a/DJYusaku/DefaultsController.swift
+++ b/DJYusaku/DefaultsController.swift
@@ -74,7 +74,11 @@ class DefaultsController: NSObject {
     // プロフィールを他のピアに送信する
     private func sendProfile() {
         if let profile = self.profile {
-            ConnectionController.shared.startAdvertise(displayName: profile.name, imageUrl: profile.imageUrl)
+            if let isDJ = ConnectionController.shared.isDJ {
+                if isDJ {
+                    ConnectionController.shared.startAdvertise(displayName: profile.name, imageUrl: profile.imageUrl)
+                }
+            }
             
             let data = try! JSONEncoder().encode(profile)
             let messageData = try! JSONEncoder().encode(MessageData(desc: MessageData.DataType.peerProfile, value: data))

--- a/DJYusaku/MemberViewController.swift
+++ b/DJYusaku/MemberViewController.swift
@@ -51,16 +51,14 @@ class MemberViewController: UIViewController {
     func updateMembers() {
         var DJName = ConnectionController.shared.isDJ!
                    ? ConnectionController.shared.peerID.displayName
-                   : ConnectionController.shared.connectedDJ?.displayName
+                   : ConnectionController.shared.connectedDJ!.peerID.displayName
         var DJIcon: UIImage? = UIImage(named: "TemporarySingleColored")
         
         listeners = ConnectionController.shared.session.connectedPeers
         
         if !ConnectionController.shared.isDJ! {
-            if let connectedDJ = ConnectionController.shared.connectedDJ {
-                // 接続している端末（親機）はtableViewには表示しない
-                self.listeners = self.listeners.filter({ $0 != connectedDJ })
-            }
+            // 接続している端末（親機）はtableViewには表示しない
+            self.listeners = self.listeners.filter({ $0 != ConnectionController.shared.connectedDJ!.peerID })
             // 子機のときは自分を先頭に挿入
             self.listeners.insert(ConnectionController.shared.peerID, at: 0)
         }
@@ -79,16 +77,14 @@ class MemberViewController: UIViewController {
                 }
             }
         } else {
-            if let connectedDJ = ConnectionController.shared.connectedDJ {
-                if let profile = ConnectionController.shared.peerProfileCorrespondence[connectedDJ] {
-                    DispatchQueue.global().async {
-                        DJName = profile.name
-                        if let imageUrl = profile.imageUrl {
-                            DJIcon = CachedImage.fetch(url: imageUrl)
-                            DispatchQueue.main.async{
-                                self.DJImageView.image = DJIcon
-                                self.DJImageView.setNeedsLayout()
-                            }
+            if let profile = ConnectionController.shared.peerProfileCorrespondence[ConnectionController.shared.connectedDJ!.peerID] {
+                DispatchQueue.global().async {
+                    DJName = profile.name
+                    if let imageUrl = profile.imageUrl {
+                        DJIcon = CachedImage.fetch(url: imageUrl)
+                        DispatchQueue.main.async{
+                            self.DJImageView.image = DJIcon
+                            self.DJImageView.setNeedsLayout()
                         }
                     }
                 }

--- a/DJYusaku/MemberViewController.swift
+++ b/DJYusaku/MemberViewController.swift
@@ -17,6 +17,7 @@ class MemberViewController: UIViewController {
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var DJNameLabel: UILabel!
     @IBOutlet weak var DJImageView: UIImageView!
+    @IBOutlet weak var DJStatusLabel: UILabel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -70,6 +71,7 @@ class MemberViewController: UIViewController {
                     DispatchQueue.main.async {
                         self.DJNameLabel.alpha = 1.0
                         self.DJImageView.alpha = 1.0
+                        self.DJStatusLabel.text = "Connecting"
                     }
                     if let imageUrl = profile.imageUrl {
                         DJIcon = CachedImage.fetch(url: imageUrl)
@@ -88,9 +90,11 @@ class MemberViewController: UIViewController {
                         if ConnectionController.shared.connectedDJ!.state != .connected {
                             self.DJNameLabel.alpha = 0.3
                             self.DJImageView.alpha = 0.3
+                            self.DJStatusLabel.text = "Missing"
                         } else {
                             self.DJNameLabel.alpha = 1.0
                             self.DJImageView.alpha = 1.0
+                            self.DJStatusLabel.text = "Connecting"
                         }
                     }
                     if let imageUrl = profile.imageUrl {

--- a/DJYusaku/MemberViewController.swift
+++ b/DJYusaku/MemberViewController.swift
@@ -67,9 +67,13 @@ class MemberViewController: UIViewController {
             if let profile = DefaultsController.shared.profile {
                 DispatchQueue.global().async {
                     DJName = profile.name
+                    DispatchQueue.main.async {
+                        self.DJNameLabel.alpha = 1.0
+                        self.DJImageView.alpha = 1.0
+                    }
                     if let imageUrl = profile.imageUrl {
                         DJIcon = CachedImage.fetch(url: imageUrl)
-                        DispatchQueue.main.async{
+                        DispatchQueue.main.async {
                             self.DJImageView.image = DJIcon
                             self.DJImageView.setNeedsLayout()
                         }
@@ -80,6 +84,15 @@ class MemberViewController: UIViewController {
             if let profile = ConnectionController.shared.peerProfileCorrespondence[ConnectionController.shared.connectedDJ!.peerID] {
                 DispatchQueue.global().async {
                     DJName = profile.name
+                    DispatchQueue.main.async {
+                        if ConnectionController.shared.connectedDJ!.state != .connected {
+                            self.DJNameLabel.alpha = 0.3
+                            self.DJImageView.alpha = 0.3
+                        } else {
+                            self.DJNameLabel.alpha = 1.0
+                            self.DJImageView.alpha = 1.0
+                        }
+                    }
                     if let imageUrl = profile.imageUrl {
                         DJIcon = CachedImage.fetch(url: imageUrl)
                         DispatchQueue.main.async{

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -11,6 +11,7 @@ import StoreKit
 import MediaPlayer
 
 extension Notification.Name {
+    static let DJYusakuRequestVCDidEnterBackground = Notification.Name("DJYusakuRequestVCDidEnterBackground")
     static let DJYusakuRequestVCWillEnterForeground = Notification.Name("DJYusakuRequestVCWillEnterForeground")
 }
 class RequestsViewController: UIViewController {
@@ -63,6 +64,7 @@ class RequestsViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(handleNowPlayingItemDidChangeOnDJ), name: .DJYusakuPlayerQueueNowPlayingSongDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handlePlaybackStateDidChange), name: .DJYusakuPlayerQueuePlaybackStateDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleNowPlayingItemDidChangeOnListener), name: .DJYusakuConnectionControllerNowPlayingSongDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleViewDidEnterBackground), name: UIApplication.didEnterBackgroundNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleViewWillEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handlePlayerControllerViewFromUserState), name: .DJYusakuUserStateDidUpdate, object: nil)
         
@@ -132,14 +134,14 @@ class RequestsViewController: UIViewController {
         }
     }
     
+    @objc func handleViewDidEnterBackground() {
+        guard ConnectionController.shared.isDJ != nil else { return }
+        NotificationCenter.default.post(name: .DJYusakuRequestVCDidEnterBackground, object: nil)
+    }
+    
     @objc func handleViewWillEnterForeground() {
         guard ConnectionController.shared.isDJ != nil else { return }
-        if !ConnectionController.shared.isDJ! {
-            NotificationCenter.default.post(
-                name: .DJYusakuRequestVCWillEnterForeground,
-                object: nil
-            )
-        }
+        NotificationCenter.default.post(name: .DJYusakuRequestVCWillEnterForeground, object: nil)
     }
     
     @objc func handlePlayerControllerViewFromUserState() {

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -96,13 +96,13 @@ extension SearchViewController: UITableViewDelegate {
             PlayerQueue.shared.add(with: song) { [unowned viewController] in
                 viewController.dismiss(animated: true)    // 1曲追加するごとにViewを閉じる
             }
-        } else {                                    // 自分がリスナーのとき
-            guard let connectedDJ = ConnectionController.shared.connectedDJ else { return }
+        } else {                                 // 自分がリスナーのとき
+            guard ConnectionController.shared.connectedDJ!.state != .connected else { return }
             let songData = try! JSONEncoder().encode(song)
             
             let messageData = try! JSONEncoder().encode(MessageData(desc:  MessageData.DataType.requestSong, value: songData))
             
-            ConnectionController.shared.session.sendRequest(messageData, toPeers: [connectedDJ], with: .unreliable) { [unowned viewController] in
+            ConnectionController.shared.session.sendRequest(messageData, toPeers: [ConnectionController.shared.connectedDJ!.peerID], with: .unreliable) { [unowned viewController] in
                 viewController.dismiss(animated: true)    // 1曲追加するごとにViewを閉じる
             }
         }

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -97,7 +97,7 @@ extension SearchViewController: UITableViewDelegate {
                 viewController.dismiss(animated: true)    // 1曲追加するごとにViewを閉じる
             }
         } else {                                 // 自分がリスナーのとき
-            guard ConnectionController.shared.connectedDJ!.state != .connected else { return }
+            guard ConnectionController.shared.connectedDJ!.state == .connected else { return }
             let songData = try! JSONEncoder().encode(song)
             
             let messageData = try! JSONEncoder().encode(MessageData(desc:  MessageData.DataType.requestSong, value: songData))

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -13,8 +13,6 @@ class WelcomeViewController: UIViewController {
     
     @IBOutlet weak var doneButtonItem: UIBarButtonItem!
     
-    static private var isViewAppearedAtLeastOnce: Bool = false;
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         


### PR DESCRIPTION
### やったこと
- （リスナー限定機能）DJを見失ったらDJのアイコンと名前が薄くなる
  - そのためにconnectedDJを(peerID: MCPeerID, state: MCSessionState)?型にする
  - connectedDJ.stateでDJと接続してるかを保持する
  - isDJがfalseのときは絶対connectedDJはnilではないという信念のもとのconnectedDJ!
- profileがセットされたら、そのprofileを使って再advertiseする
  - Twitterのログイン情報がUserDefaultsに保存されていてTwitterのprofileが有効なら、自動的にそれを使ってadvertiseするようになった
- 誰かと接続したときだけでなく、誰かと切断したときもSessionタブの中身を更新

### バグっぽいところ
DJを見失ってDJのアイコンと名前が薄くなるとき、DJの名前がデバイス名になってしまうことがある
`updateMembers`の`DispatchQueue`周りがアレそう （関連 #91）

### やるかどうか迷ってるところ
DefaultsControllerのprofileをPeerProfile型にして、初期値にPeerProfile(name: UIDevice.current.name, imageUrl: nil)を与えるようにするやつ

### やってほしいこと
動作確認。（リスナからの曲のリクエストとかがちゃんと動いてるか確認してほしい）
