### PR TITLE
Sessionタブで名前やイメージがちらつく問題を修正ほか

### DIFF
--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -512,7 +512,7 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="TemporarySingleColored" translatesAutoresizingMaskIntoConstraints="NO" id="Ynj-sW-L7l" userLabel="PeerImage">
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ynj-sW-L7l" userLabel="PeerImage">
                                                     <rect key="frame" x="8" y="8" width="48" height="48"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="48" id="f4H-6d-uzd"/>

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -765,7 +765,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="TemporarySingleColored" translatesAutoresizingMaskIntoConstraints="NO" id="fpU-yS-Emb" userLabel="PeerImage">
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="fpU-yS-Emb" userLabel="PeerImage">
                                                     <rect key="frame" x="15" y="2" width="40" height="40"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="40" id="2GT-bu-IGl"/>
@@ -799,7 +799,7 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="TemporarySingleColored" translatesAutoresizingMaskIntoConstraints="NO" id="KmF-kX-f76" userLabel="PeerImage">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="KmF-kX-f76" userLabel="PeerImage">
                                 <rect key="frame" x="143" y="111" width="128" height="128"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="128" id="KBs-ay-c8n"/>

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -91,11 +91,8 @@ class ConnectionController: NSObject {
     
     func startDJ() {
         self.disconnect()
-        if let profile = DefaultsController.shared.profile {
-            startAdvertise(displayName: profile.name, imageUrl: profile.imageUrl)
-        } else {
-            startAdvertise(displayName: UIDevice.current.name, imageUrl: nil)
-        }
+        let profile = DefaultsController.shared.profile
+        startAdvertise(displayName: profile.name, imageUrl: profile.imageUrl)
         self.isDJ = true
         NotificationCenter.default.post(name: .DJYusakuPeerConnectionStateDidUpdate, object: nil)
         NotificationCenter.default.post(name: .DJYusakuUserStateDidUpdate, object: nil)
@@ -136,12 +133,10 @@ extension ConnectionController: MCSessionDelegate {
             print("Peer \(peerID.displayName) is connected.")
             NotificationCenter.default.post(name: .DJYusakuPeerConnectionStateDidUpdate, object: nil)
             
-            // プロフィールが設定されていれば他のピアに送信する
-            if let profile = DefaultsController.shared.profile {
-                let data = try! JSONEncoder().encode(profile)
-                let messageData = try! JSONEncoder().encode(MessageData(desc:  MessageData.DataType.peerProfile, value: data))
-                self.session.sendRequest(messageData, toPeers: [peerID], with: .unreliable)
-            }
+            // 接続したらプロフィールを他のピアに送信する
+            let data = try! JSONEncoder().encode(DefaultsController.shared.profile)
+            let messageData = try! JSONEncoder().encode(MessageData(desc:  MessageData.DataType.peerProfile, value: data))
+            self.session.sendRequest(messageData, toPeers: [peerID], with: .unreliable)
             
             if ConnectionController.shared.isDJ! {   // DJが新しい子機と接続したとき
                 var songs: [Song] = []

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -97,6 +97,7 @@ class ConnectionController: NSObject {
             startAdvertise(displayName: UIDevice.current.name, imageUrl: nil)
         }
         self.isDJ = true
+        NotificationCenter.default.post(name: .DJYusakuPeerConnectionStateDidUpdate, object: nil)
         NotificationCenter.default.post(name: .DJYusakuUserStateDidUpdate, object: nil)
     }
     

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -22,24 +22,23 @@ class ConnectionController: NSObject {
     
     public weak var delegate: ConnectionControllerDelegate?
     
-    let serviceType = "djyusaku"
+    private let serviceType = "djyusaku"
     
-    var peerID = MCPeerID(displayName: UIDevice.current.name)
-    var session: MCSession!
-    var advertiser: MCNearbyServiceAdvertiser!
-    var browser: MCNearbyServiceBrowser!
+    let peerID = MCPeerID(displayName: UIDevice.current.name)
+    private(set) var session: MCSession!
+    private var advertiser: MCNearbyServiceAdvertiser!
+    private var browser: MCNearbyServiceBrowser!
     
     private(set) var isInitialized = false
     
-    var isDJ: Bool? = nil
-    var connectedDJ: (peerID: MCPeerID, state: MCSessionState)? = nil
+    private(set) var isDJ: Bool? = nil
+    private(set) var connectedDJ: (peerID: MCPeerID, state: MCSessionState)? = nil
     
     var peerProfileCorrespondence: [MCPeerID:PeerProfile] = [:]
     
     var connectableDJs: [MCPeerID] = [] //  ListenerConnectionViewController用
     
-    var receivedSongs: [Song] = [] // リスナー用
-    
+    private(set) var receivedSongs: [Song] = [] // リスナー用
     
     func initialize() {
         self.session = MCSession(peer: self.peerID)
@@ -90,21 +89,21 @@ class ConnectionController: NSObject {
     }
     
     func startDJ() {
+        self.isDJ = true
         self.disconnect()
         let profile = DefaultsController.shared.profile
         startAdvertise(displayName: profile.name, imageUrl: profile.imageUrl)
-        self.isDJ = true
         NotificationCenter.default.post(name: .DJYusakuPeerConnectionStateDidUpdate, object: nil)
         NotificationCenter.default.post(name: .DJYusakuUserStateDidUpdate, object: nil)
     }
     
     func startListener(selectedDJ: MCPeerID) {
+        self.isDJ = false
         if selectedDJ != self.connectedDJ?.peerID {
             self.disconnect()
         }
         self.browser.invitePeer(selectedDJ, to: session, withContext: nil, timeout: 10.0)
         self.connectedDJ = (selectedDJ, .connected)
-        self.isDJ = false
         if self.advertiser != nil {
             self.advertiser.stopAdvertisingPeer()
         }
@@ -122,7 +121,7 @@ extension ConnectionController: MCSessionDelegate {
         case .notConnected:
             print("Peer \(peerID.displayName) is disconnected.")
             NotificationCenter.default.post(name: .DJYusakuPeerConnectionStateDidUpdate, object: nil)
-            if !ConnectionController.shared.isDJ! && peerID == connectedDJ?.peerID { // リスナーがDJを見失ったとき
+            if !self.isDJ! && peerID == self.connectedDJ?.peerID { // リスナーがDJを見失ったとき
                 self.connectedDJ!.state = .notConnected
             }
             break
@@ -138,7 +137,7 @@ extension ConnectionController: MCSessionDelegate {
             let messageData = try! JSONEncoder().encode(MessageData(desc:  MessageData.DataType.peerProfile, value: data))
             self.session.sendRequest(messageData, toPeers: [peerID], with: .unreliable)
             
-            if ConnectionController.shared.isDJ! {   // DJが新しい子機と接続したとき
+            if self.isDJ! {   // DJが新しい子機と接続したとき
                 var songs: [Song] = []
                 for i in 0..<PlayerQueue.shared.count() {
                     songs.append(PlayerQueue.shared.get(at: i)!)

--- a/DJYusaku/DefaultsController.swift
+++ b/DJYusaku/DefaultsController.swift
@@ -32,7 +32,7 @@ class DefaultsController: NSObject {
     private(set) var twitterAccount: TwitterAccount? = nil
     private(set) var swifter : Swifter = Swifter(consumerKey: Secrets.TwitterConsumerKey,
                                                  consumerSecret: Secrets.TwitterConsumerSecret)
-    private(set) var profile: PeerProfile? = nil
+    private(set) var profile: PeerProfile = PeerProfile(name: UIDevice.current.name, imageUrl: nil)
     private(set) var willUseTwitterProfile : Bool = false
     
     private override init() {
@@ -73,20 +73,18 @@ class DefaultsController: NSObject {
     
     // プロフィールを他のピアに送信する
     private func sendProfile() {
-        if let profile = self.profile {
-            if let isDJ = ConnectionController.shared.isDJ {
-                if isDJ {
-                    ConnectionController.shared.startAdvertise(displayName: profile.name, imageUrl: profile.imageUrl)
-                }
+        if let isDJ = ConnectionController.shared.isDJ {
+            if isDJ {
+                ConnectionController.shared.startAdvertise(displayName: profile.name, imageUrl: profile.imageUrl)
             }
-            
-            let data = try! JSONEncoder().encode(profile)
-            let messageData = try! JSONEncoder().encode(MessageData(desc: MessageData.DataType.peerProfile, value: data))
-            ConnectionController.shared.session.sendRequest(messageData,
-                                                            toPeers: ConnectionController.shared.session.connectedPeers,
-                                                            with: .unreliable)
-            NotificationCenter.default.post(name: .DJYusakuPeerConnectionStateDidUpdate, object: nil)
         }
+        
+        let data = try! JSONEncoder().encode(profile)
+        let messageData = try! JSONEncoder().encode(MessageData(desc: MessageData.DataType.peerProfile, value: data))
+        ConnectionController.shared.session.sendRequest(messageData,
+                                                        toPeers: ConnectionController.shared.session.connectedPeers,
+                                                        with: .unreliable)
+        NotificationCenter.default.post(name: .DJYusakuPeerConnectionStateDidUpdate, object: nil)
     }
     
     @objc func handleUserDefaultsDidChange(_ notification: Notification) {

--- a/DJYusaku/ListenerConnectionViewController.swift
+++ b/DJYusaku/ListenerConnectionViewController.swift
@@ -42,11 +42,15 @@ extension ListenerConnectionViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "ListenerConnectableDJsTableViewCell", for: indexPath) as! ListenerConnectableDJsTableViewCell
-        let peerID = ConnectionController.shared.connectableDJs[indexPath.row]
-        if let profile = ConnectionController.shared.peerProfileCorrespondence[peerID] {
-            cell.djName?.text = profile.name
+        var DJImage: UIImage?
+        let profile = ConnectionController.shared.peerProfileCorrespondence[ConnectionController.shared.connectableDJs[indexPath.row]]!
+        cell.djName?.text = profile.name
+        DispatchQueue.global().async {
             if let imageUrl = profile.imageUrl {
-                cell.djImageView.image = CachedImage.fetch(url: imageUrl)
+                DJImage = CachedImage.fetch(url: imageUrl)
+            }
+            DispatchQueue.main.async {
+                cell.djImageView.image = DJImage ?? UIImage(named: "TemporarySingleColored")
             }
         }
 

--- a/DJYusaku/ListenerConnectionViewController.swift
+++ b/DJYusaku/ListenerConnectionViewController.swift
@@ -63,9 +63,8 @@ extension ListenerConnectionViewController: UITableViewDataSource {
 extension ListenerConnectionViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let selectedDJ = ConnectionController.shared.connectableDJs[indexPath.row]
-        self.dismiss(animated: true) {
-            ConnectionController.shared.startListener(selectedDJ: selectedDJ)
-        }
+        ConnectionController.shared.startListener(selectedDJ: selectedDJ)
+        self.dismiss(animated: true)
     }
 }
 

--- a/DJYusaku/MemberViewController.swift
+++ b/DJYusaku/MemberViewController.swift
@@ -65,20 +65,19 @@ class MemberViewController: UIViewController {
         }
         
         if ConnectionController.shared.isDJ! {
-            if let profile = DefaultsController.shared.profile {
-                DispatchQueue.global().async {
-                    DJName = profile.name
+            let profile = DefaultsController.shared.profile
+            DispatchQueue.global().async {
+                DJName = profile.name
+                DispatchQueue.main.async {
+                    self.DJNameLabel.alpha = 1.0
+                    self.DJImageView.alpha = 1.0
+                    self.DJStatusLabel.text = "Connecting"
+                }
+                if let imageUrl = profile.imageUrl {
+                    DJIcon = CachedImage.fetch(url: imageUrl)
                     DispatchQueue.main.async {
-                        self.DJNameLabel.alpha = 1.0
-                        self.DJImageView.alpha = 1.0
-                        self.DJStatusLabel.text = "Connecting"
-                    }
-                    if let imageUrl = profile.imageUrl {
-                        DJIcon = CachedImage.fetch(url: imageUrl)
-                        DispatchQueue.main.async {
-                            self.DJImageView.image = DJIcon
-                            self.DJImageView.setNeedsLayout()
-                        }
+                        self.DJImageView.image = DJIcon
+                        self.DJImageView.setNeedsLayout()
                     }
                 }
             }
@@ -139,16 +138,15 @@ extension MemberViewController: UITableViewDataSource {
             var listenerName: String?
             var listenerIcon: UIImage?
             if indexPath.row == 0 && !ConnectionController.shared.isDJ! { // 自分自身（子機）
-                if let profile = DefaultsController.shared.profile {
-                    listenerName = profile.name
-                    if let imageUrl = profile.imageUrl {
-                        listenerIcon = CachedImage.fetch(url: imageUrl)
-                    }
-                    DispatchQueue.main.async {
-                        cell.peerName.text       = listenerName
-                        cell.peerImageView.image = listenerIcon
-                        cell.peerImageView.setNeedsLayout()
-                    }
+                let profile = DefaultsController.shared.profile
+                listenerName = profile.name
+                if let imageUrl = profile.imageUrl {
+                    listenerIcon = CachedImage.fetch(url: imageUrl)
+                }
+                DispatchQueue.main.async {
+                    cell.peerName.text       = listenerName
+                    cell.peerImageView.image = listenerIcon
+                    cell.peerImageView.setNeedsLayout()
                 }
             } else { // 自分以外の子機
                 if let profile = ConnectionController.shared.peerProfileCorrespondence[self.listeners[indexPath.row]] {

--- a/DJYusaku/MemberViewController.swift
+++ b/DJYusaku/MemberViewController.swift
@@ -50,12 +50,12 @@ class MemberViewController: UIViewController {
     }
     
     func updateMembers() {
-        var DJName = ConnectionController.shared.isDJ!
-                   ? ConnectionController.shared.peerID.displayName
-                   : ConnectionController.shared.connectedDJ!.peerID.displayName
-        var DJIcon: UIImage? = UIImage(named: "TemporarySingleColored")
+        let DJName = ConnectionController.shared.isDJ!
+                   ? DefaultsController.shared.profile.name
+                   : ConnectionController.shared.peerProfileCorrespondence[ConnectionController.shared.connectedDJ!.peerID]!.name
+        var DJIcon: UIImage?
         
-        listeners = ConnectionController.shared.session.connectedPeers
+        self.listeners = ConnectionController.shared.session.connectedPeers
         
         if !ConnectionController.shared.isDJ! {
             // 接続している端末（親機）はtableViewには表示しない
@@ -65,52 +65,42 @@ class MemberViewController: UIViewController {
         }
         
         if ConnectionController.shared.isDJ! {
-            let profile = DefaultsController.shared.profile
             DispatchQueue.global().async {
-                DJName = profile.name
+                if let imageUrl = DefaultsController.shared.profile.imageUrl {
+                    DJIcon = CachedImage.fetch(url: imageUrl)
+                }
                 DispatchQueue.main.async {
                     self.DJNameLabel.alpha = 1.0
                     self.DJImageView.alpha = 1.0
                     self.DJStatusLabel.text = "Connecting"
-                }
-                if let imageUrl = profile.imageUrl {
-                    DJIcon = CachedImage.fetch(url: imageUrl)
-                    DispatchQueue.main.async {
-                        self.DJImageView.image = DJIcon
-                        self.DJImageView.setNeedsLayout()
-                    }
+                    self.DJImageView.image = DJIcon ?? UIImage(named: "TemporarySingleColored")
+                    self.DJImageView.setNeedsLayout()
                 }
             }
         } else {
-            if let profile = ConnectionController.shared.peerProfileCorrespondence[ConnectionController.shared.connectedDJ!.peerID] {
-                DispatchQueue.global().async {
-                    DJName = profile.name
-                    DispatchQueue.main.async {
-                        if ConnectionController.shared.connectedDJ!.state != .connected {
-                            self.DJNameLabel.alpha = 0.3
-                            self.DJImageView.alpha = 0.3
-                            self.DJStatusLabel.text = "Missing"
-                        } else {
-                            self.DJNameLabel.alpha = 1.0
-                            self.DJImageView.alpha = 1.0
-                            self.DJStatusLabel.text = "Connecting"
-                        }
+            DispatchQueue.global().async {
+                if let imageUrl = ConnectionController.shared.peerProfileCorrespondence[ConnectionController.shared.connectedDJ!.peerID]!.imageUrl {
+                    DJIcon = CachedImage.fetch(url: imageUrl)
+                }
+                DispatchQueue.main.async {
+                    if ConnectionController.shared.connectedDJ!.state != .connected {
+                        self.DJNameLabel.alpha = 0.3
+                        self.DJImageView.alpha = 0.3
+                        self.DJStatusLabel.text = "Missing"
+                    } else {
+                        self.DJNameLabel.alpha = 1.0
+                        self.DJImageView.alpha = 1.0
+                        self.DJStatusLabel.text = "Connecting"
                     }
-                    if let imageUrl = profile.imageUrl {
-                        DJIcon = CachedImage.fetch(url: imageUrl)
-                        DispatchQueue.main.async{
-                            self.DJImageView.image = DJIcon
-                            self.DJImageView.setNeedsLayout()
-                        }
-                    }
+                    self.DJImageView.image = DJIcon ?? UIImage(named: "TemporarySingleColored")
+                    self.DJImageView.setNeedsLayout()
                 }
             }
         }
         
         // 親機の表示を更新
-        DispatchQueue.main.async{
+        DispatchQueue.main.async {
             self.DJNameLabel.text  = DJName
-            self.DJImageView.image = DJIcon
             self.tableView.reloadData()
         }
     }
@@ -125,44 +115,42 @@ class MemberViewController: UIViewController {
 
 extension MemberViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return listeners.count
+        return self.listeners.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell  = tableView.dequeueReusableCell(withIdentifier: "MemberTableViewCell", for: indexPath) as! MemberTableViewCell
-        cell.peerName.text       = listeners[indexPath.row].displayName
-        cell.peerImageView.image = UIImage(named: "TemporarySingleColored")
-        
-        // プロフィールが設定されている場合
-        DispatchQueue.global().async {
-            var listenerName: String?
-            var listenerIcon: UIImage?
-            if indexPath.row == 0 && !ConnectionController.shared.isDJ! { // 自分自身（子機）
-                let profile = DefaultsController.shared.profile
-                listenerName = profile.name
+        var listenerIcon: UIImage?
+        if indexPath.row == 0 && !ConnectionController.shared.isDJ! { // 自分自身（子機）
+            let profile = DefaultsController.shared.profile
+            cell.peerName.text = profile.name
+            DispatchQueue.global().async {
                 if let imageUrl = profile.imageUrl {
                     listenerIcon = CachedImage.fetch(url: imageUrl)
                 }
                 DispatchQueue.main.async {
-                    cell.peerName.text       = listenerName
-                    cell.peerImageView.image = listenerIcon
+                    cell.peerImageView.image = listenerIcon ?? UIImage(named: "TemporarySingleColored")
                     cell.peerImageView.setNeedsLayout()
                 }
-            } else { // 自分以外の子機
-                if let profile = ConnectionController.shared.peerProfileCorrespondence[self.listeners[indexPath.row]] {
-                    listenerName = profile.name
+            }
+        } else { // 自分以外の子機
+            if let profile = ConnectionController.shared.peerProfileCorrespondence[self.listeners[indexPath.row]] {
+                cell.peerName.text = profile.name
+                DispatchQueue.global().async {
                     if let imageUrl = profile.imageUrl {
                         listenerIcon = CachedImage.fetch(url: imageUrl)
                     }
                     DispatchQueue.main.async {
-                        cell.peerName.text       = listenerName
-                        cell.peerImageView.image = listenerIcon
+                        cell.peerImageView.image = listenerIcon ?? UIImage(named: "TemporarySingleColored")
                         cell.peerImageView.setNeedsLayout()
                     }
                 }
+            } else { // このリスナーのprofileをまだ受け取ってないとき
+                cell.peerName.text = self.listeners[indexPath.row].displayName
             }
+            
         }
-        
+             
         return cell
     }
  }

--- a/DJYusaku/MemberViewController.swift
+++ b/DJYusaku/MemberViewController.swift
@@ -53,7 +53,7 @@ class MemberViewController: UIViewController {
         let DJName = ConnectionController.shared.isDJ!
                    ? DefaultsController.shared.profile.name
                    : ConnectionController.shared.peerProfileCorrespondence[ConnectionController.shared.connectedDJ!.peerID]!.name
-        var DJIcon: UIImage?
+        var DJImage: UIImage?
         
         self.listeners = ConnectionController.shared.session.connectedPeers
         
@@ -67,20 +67,20 @@ class MemberViewController: UIViewController {
         if ConnectionController.shared.isDJ! {
             DispatchQueue.global().async {
                 if let imageUrl = DefaultsController.shared.profile.imageUrl {
-                    DJIcon = CachedImage.fetch(url: imageUrl)
+                    DJImage = CachedImage.fetch(url: imageUrl)
                 }
                 DispatchQueue.main.async {
                     self.DJNameLabel.alpha = 1.0
                     self.DJImageView.alpha = 1.0
                     self.DJStatusLabel.text = "Connecting"
-                    self.DJImageView.image = DJIcon ?? UIImage(named: "TemporarySingleColored")
+                    self.DJImageView.image = DJImage ?? UIImage(named: "TemporarySingleColored")
                     self.DJImageView.setNeedsLayout()
                 }
             }
         } else {
             DispatchQueue.global().async {
                 if let imageUrl = ConnectionController.shared.peerProfileCorrespondence[ConnectionController.shared.connectedDJ!.peerID]!.imageUrl {
-                    DJIcon = CachedImage.fetch(url: imageUrl)
+                    DJImage = CachedImage.fetch(url: imageUrl)
                 }
                 DispatchQueue.main.async {
                     if ConnectionController.shared.connectedDJ!.state != .connected {
@@ -92,7 +92,7 @@ class MemberViewController: UIViewController {
                         self.DJImageView.alpha = 1.0
                         self.DJStatusLabel.text = "Connecting"
                     }
-                    self.DJImageView.image = DJIcon ?? UIImage(named: "TemporarySingleColored")
+                    self.DJImageView.image = DJImage ?? UIImage(named: "TemporarySingleColored")
                     self.DJImageView.setNeedsLayout()
                 }
             }
@@ -120,16 +120,16 @@ extension MemberViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell  = tableView.dequeueReusableCell(withIdentifier: "MemberTableViewCell", for: indexPath) as! MemberTableViewCell
-        var listenerIcon: UIImage?
+        var listenerImage: UIImage?
         if indexPath.row == 0 && !ConnectionController.shared.isDJ! { // 自分自身（子機）
             let profile = DefaultsController.shared.profile
             cell.peerName.text = profile.name
             DispatchQueue.global().async {
                 if let imageUrl = profile.imageUrl {
-                    listenerIcon = CachedImage.fetch(url: imageUrl)
+                    listenerImage = CachedImage.fetch(url: imageUrl)
                 }
                 DispatchQueue.main.async {
-                    cell.peerImageView.image = listenerIcon ?? UIImage(named: "TemporarySingleColored")
+                    cell.peerImageView.image = listenerImage ?? UIImage(named: "TemporarySingleColored")
                     cell.peerImageView.setNeedsLayout()
                 }
             }
@@ -138,10 +138,10 @@ extension MemberViewController: UITableViewDataSource {
                 cell.peerName.text = profile.name
                 DispatchQueue.global().async {
                     if let imageUrl = profile.imageUrl {
-                        listenerIcon = CachedImage.fetch(url: imageUrl)
+                        listenerImage = CachedImage.fetch(url: imageUrl)
                     }
                     DispatchQueue.main.async {
-                        cell.peerImageView.image = listenerIcon ?? UIImage(named: "TemporarySingleColored")
+                        cell.peerImageView.image = listenerImage ?? UIImage(named: "TemporarySingleColored")
                         cell.peerImageView.setNeedsLayout()
                     }
                 }

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -178,7 +178,7 @@ extension SearchViewController: UISearchResultsUpdating {
                     let artworkUrlString = song["attributes"]["artwork"]["url"].stringValue
                     let songID           = song["attributes"]["playParams"]["id"].stringValue
                     let artworkUrl = CachedImage.url(urlString: artworkUrlString, width: 256, height: 256)
-                    self.results.append(Song(title: title, artist: artist, artworkUrl: artworkUrl, id: songID, profileImageUrl: DefaultsController.shared.profile?.imageUrl))
+                    self.results.append(Song(title: title, artist: artist, artworkUrl: artworkUrl, id: songID, profileImageUrl: DefaultsController.shared.profile.imageUrl))
                 }
                 self.tableView.reloadData()
             }


### PR DESCRIPTION
### やったこと
- startDJ()の後にSessionタブをアップデートする
- DefaultsControllerのprofileをPeerProfile型にする
- MemberViewControllerの再描画を改良 （関連 #91 ）
- ListenerConnectionViewControllerでのTableViewのイメージも非同期に取得する
- DJを選択してリスナーになるとき、dissmissのcompletionを使わない（関連 #80 ）

### やってほしいこと
めちゃくちゃに動かして落ちたりしないか。DJを選択してリスナーになるときIndexOutOfRangeで落ちたりしないか。