### PR TITLE
Settings画面の再描画

### DIFF
--- a/DJYusaku/SettingsViewController.swift
+++ b/DJYusaku/SettingsViewController.swift
@@ -34,6 +34,9 @@ class SettingsViewController: UITableViewController, SFSafariViewControllerDeleg
             self.twitterAccountLabel.text = "@" + twitterAccount.screenName
         }
         
+        DispatchQueue.main.async {
+            self.tableView.reloadData()
+        }
     }
     
     
@@ -98,6 +101,8 @@ class SettingsNameViewController: UITableViewController, UITextFieldDelegate {
         // 既に名前が設定されていればテキストボックスに名前を表示
         self.nameField.text = UserDefaults.standard.string(forKey: UserDefaults.DJYusakuDefaults.ProfileName)
     }
+    
+    // MARK: - UITextFieldDelegate
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         self.nameField.resignFirstResponder()

--- a/DJYusaku/SettingsViewController.swift
+++ b/DJYusaku/SettingsViewController.swift
@@ -73,6 +73,7 @@ class SettingsViewController: UITableViewController, SFSafariViewControllerDeleg
                                                     screenName: token.screenName!)
                 let data = try! JSONEncoder().encode(twitterAccount)
                 UserDefaults.standard.set(data, forKey: UserDefaults.DJYusakuDefaults.TwitterAccount)
+                self.twitterAccountLabel.text = "@" + twitterAccount.screenName
             }, failure: { error in
                 print("Swifter Error at SettingsViewController.tableViewTwitterSection():", error.localizedDescription)
             })


### PR DESCRIPTION
### やったこと
#90 を直しました （というか直りました）

- Name設定してSettings画面に戻ってきたとき、その変更が反映されてない問題
  - viewWillAppearの最後に`self.tableView.reloadData()`で解決！
- TwitterログインしてSFSafariViewから戻ってきたとき、Twitterのscreennameが反映されてない問題
  - コールバックの最後で`self.twitterAccountLabel.text`に入れてやれば解決！
  - SFSafariViewを閉じたときviewWillAppearは呼ばれないため、これが必要（呼ばれないの謎）