### PR TITLE
検索画面で前回の画像フェッチがDispatchQueueに残っていた場合破棄するようにした

### DIFF
--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -17,6 +17,9 @@ class SearchViewController: UIViewController {
     private var storefrontCountryCode : String? = nil
     private var results : [Song] = []
     private let defaultArtwork : UIImage = UIImage()
+    // 画像の取得の際に用いるキュー
+    private let imageFetchQueue = DispatchQueue(label: "DJYusakuImageFetch", qos:.userInteractive)
+    private var imageFetchWorkItem : [DispatchWorkItem?] = [DispatchWorkItem?](repeating: nil, count: 25)
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -72,13 +75,16 @@ extension SearchViewController: UITableViewDataSource {
         cell.artist.text      = item.artist
         cell.artwork.image    = defaultArtwork
         
-        DispatchQueue.global().async {
+        self.imageFetchWorkItem[indexPath.row]?.cancel()
+        self.imageFetchWorkItem[indexPath.row] = DispatchWorkItem {
             let image = CachedImage.fetch(url: item.artworkUrl)
             DispatchQueue.main.async {
                 cell.artwork.image = image  // 画像の取得に失敗していたらnilが入ることに注意
                 cell.artwork.setNeedsLayout()
             }
         }
+        imageFetchQueue.async(execute: self.imageFetchWorkItem[indexPath.row]!)
+        
         return cell
     }
 }


### PR DESCRIPTION
#10 が直ったと思う

### やってほしいこと

コードレビューと動作確認  
動作確認の際には

1. 適当に英語の比較的長い曲名を入力する
2. すべての検索結果が出る前に曲名をガーっと数文字削除する
3. 再度削除した文の文字を再入力する

今までだと 2. と 3. で前の画像が残っちゃったりしてたのが直ってるはず

### 参考

https://qiita.com/nariakiiwatani/items/5710050ee5778763f9f2