### PR TITLE
参加人数の制限について

### DIFF
--- a/DJYusaku/ListenerConnectionViewController.swift
+++ b/DJYusaku/ListenerConnectionViewController.swift
@@ -51,7 +51,9 @@ extension ListenerConnectionViewController: UITableViewDataSource {
             cell.numberOfParticipants?.text = "\(numberOfParticipants)/8"
             if numberOfParticipants == 8 {
                 cell.numberOfParticipantsBackgroundView.layer.backgroundColor = CGColor(srgbRed: 1.0, green: 0.0, blue: 0.0, alpha: 1.0)
-                cell.selectionStyle = .none
+                cell.djImageView.alpha = 0.3
+                cell.djName.alpha      = 0.3
+                cell.selectionStyle    = .none
             }
         }
         DispatchQueue.global().async {

--- a/DJYusaku/ListenerConnectionViewController.swift
+++ b/DJYusaku/ListenerConnectionViewController.swift
@@ -51,6 +51,7 @@ extension ListenerConnectionViewController: UITableViewDataSource {
             cell.numberOfParticipants?.text = "\(numberOfParticipants)/8"
             if numberOfParticipants == 8 {
                 cell.numberOfParticipantsBackgroundView.layer.backgroundColor = CGColor(srgbRed: 1.0, green: 0.0, blue: 0.0, alpha: 1.0)
+                cell.selectionStyle = .none
             }
         }
         DispatchQueue.global().async {
@@ -70,9 +71,11 @@ extension ListenerConnectionViewController: UITableViewDataSource {
 
 extension ListenerConnectionViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let selectedDJ = ConnectionController.shared.connectableDJs[indexPath.row]
-        ConnectionController.shared.startListener(selectedDJ: selectedDJ)
-        self.dismiss(animated: true)
+        if ConnectionController.shared.numberOfParticipantsCorrespondence[ConnectionController.shared.connectableDJs[indexPath.row]] != 8 {
+            let selectedDJ = ConnectionController.shared.connectableDJs[indexPath.row]
+            ConnectionController.shared.startListener(selectedDJ: selectedDJ)
+            self.dismiss(animated: true)
+        }
     }
 }
 


### PR DESCRIPTION
## 概要
`MultipeerConnectivity`の仕様では1セッション辺りの参加可能人数は8人までとなっているが、現在のDJYusakuだと参加人数が8人に達したセッションは表示が変わるものの、そのセッションを選択して参加できてしまう。また、多くの数(合計8人以上)が一斉にセッション内に入った時の処理も実装していないため意図しないバグを引き起こす恐れがある。従ってこのプルリクエストではそれらの問題を解決する処理を実装する。

## 進行状況

- [x] 現在の参加人数が8人のセッションは選択できないように変更
- [x] 名前とアイコンを灰色に変更
## 関連
#109