### PR TITLE
MPMusicPlayerControllerNowPlayingItemDidChangeが呼ばれないバグを修正

### DIFF
--- a/DJYusaku/PlayerQueue.swift
+++ b/DJYusaku/PlayerQueue.swift
@@ -45,6 +45,7 @@ class PlayerQueue{
     
     private init(){
         mpAppController.repeatMode = MPMusicRepeatMode.all
+        mpAppController.beginGeneratingPlaybackNotifications()
         NotificationCenter.default.addObserver(self, selector: #selector(handleNowPlayingItemDidChange), name: .MPMusicPlayerControllerNowPlayingItemDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handlePlaybackStateDidChange), name: .MPMusicPlayerControllerPlaybackStateDidChange, object: nil)
     }


### PR DESCRIPTION
例のアレが直ったと思います。

### 何がいけなかったのか

MPMusicPlayerControllerが通知を発するためには関数 `beginGeneratingPlaybackNotifications()` を呼ぶ必要があったが、呼ぶのを忘れていた。  
ところが、この関数を呼んでいないにも関わらずなぜかMPMusicPlayerControllerから通知が出てくる場合があり、そのためこのバグを見落としていた。

### やってほしいこと

動作確認はこちらでしている（バッテリーセーバーモードで数曲の切り替えができることを確認済み）ので、コードレビューだけで結構です（1行書き足すだけなので）