### PR TITLE
Apple Musicを契約してない人がNew Sessionを押したときアラートを表示

### DIFF
--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -52,6 +52,8 @@ class ConnectionController: NSObject {
         }
     }
     
+    var canPlayAppleMusic = false
+
     func initialize() {
         self.session = MCSession(peer: self.peerID)
         self.session.delegate = self

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -64,6 +64,7 @@ class RequestsViewController: UIViewController {
             // Apple Musicの曲が再生可能か確認
             self.cloudServiceController.requestCapabilities { (capabilities, error) in
                 guard error == nil && capabilities.contains(.musicCatalogPlayback) else { return }
+                ConnectionController.shared.canPlayAppleMusic = true
             }
         }
         

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -47,7 +47,7 @@ class SearchViewController: UIViewController {
             if error != nil {
                 // アラートを表示
                 let alertController = UIAlertController(title:   "Apple Music connection failed".localized,
-                                                        message: "Please check your online status or iCloud account status.".localized,
+                                                        message: "Please check your online status or Apple Music access permission at \"Settings\" app.".localized,
                                                         preferredStyle: UIAlertController.Style.alert)
                 let alertButton = UIAlertAction(title: "OK",
                                                 style: UIAlertAction.Style.cancel) { action in

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -70,6 +70,20 @@ class WelcomeViewController: UIViewController {
     }
     
     @IBAction func joinAsDJ(_ sender: Any) {
+        if !ConnectionController.shared.canPlayAppleMusic {
+            // アラートを表示
+            let alertController = UIAlertController(title:   "Apple Music membership could not be confirmed".localized,
+                                                    message: "Apple Music songs are not played in this session.".localized,
+                                                    preferredStyle: .alert)
+            let alertButton = UIAlertAction(title: "OK",
+                                            style: .cancel) { action in
+                                                ConnectionController.shared.startDJ()
+                                                self.dismiss(animated: true)
+            }
+            alertController.addAction(alertButton)
+            self.present(alertController, animated: true, completion: nil)
+            return
+        }
         ConnectionController.shared.startDJ()
         
         self.dismiss(animated: true, completion: nil)

--- a/DJYusaku/en.lproj/Localizable.strings
+++ b/DJYusaku/en.lproj/Localizable.strings
@@ -26,3 +26,7 @@
 "Missing" = "Missing";
 "Connecting" = "Connecting";
 "You" = "You";
+
+// WelcomeViewController.swift
+"Apple Music membership could not be confirmed" = "Apple Music membership could not be confirmed";
+"Apple Music songs are not played in this session." = "Apple Music songs are not played in this session.";

--- a/DJYusaku/en.lproj/Localizable.strings
+++ b/DJYusaku/en.lproj/Localizable.strings
@@ -20,7 +20,7 @@
 
 // SearchViewController.swift
 "Apple Music connection failed" = "Apple Music connection failed";
-"Please check your online status or iCloud account status." = "Please check your online status or iCloud account status.";
+"Please check your online status or Apple Music access permission at \"Settings\" app." = "Please check your online status or Apple Music access permission at \"Settings\" app.";
 
 // MemberViewController.swift
 "Missing" = "Missing";

--- a/DJYusaku/ja.lproj/Localizable.strings
+++ b/DJYusaku/ja.lproj/Localizable.strings
@@ -19,7 +19,7 @@
 
 // SearchViewController.swift
 "Apple Music connection failed" = "Apple Musicとの接続に失敗しました";
-"Please check your online status or iCloud account status." = "インターネットまたはiCloudアカウントの状態を確認してください。";
+"Please check your online status or Apple Music access permission at \"Settings\" app." = "インターネットの状態または「設定」アプリでApple Musicの許可を確認してください。";
 
 // MemberViewController.swift
 "Missing" = "未接続";

--- a/DJYusaku/ja.lproj/Localizable.strings
+++ b/DJYusaku/ja.lproj/Localizable.strings
@@ -25,3 +25,7 @@
 "Missing" = "未接続";
 "Connecting" = "接続中";
 "You" = "あなた";
+
+// WelcomeViewController.swift
+"Apple Music membership could not be confirmed" = "Apple Musicのメンバーシップを確認できませんでした";
+"Apple Music songs are not played in this session." = "このセッションではApple Musicの楽曲は再生されません。";


### PR DESCRIPTION
最終的に、Apple Musicを契約してない人がNew Sessionを押したとき
* アラート表示して他何もできなくする
* アラート表示して他今までのまま曲の再生以外何でもできる

で迷って、結局~前者~後者にしました。

ConnectionControllerを便利なグローバル変数置き場みたいに使ってしまってすみません。

### やって欲しいこと
Apple Music契約してるみなさんでもシステム環境設定からApple Musicのアクセス許可を取り消せば試せます。