### PR TITLE
検索画面での連打による複数リクエストを防ぐ

### DIFF
--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -23,6 +23,7 @@ class SearchViewController: UIViewController {
     // 画像の取得の際に用いるキュー
     private let imageFetchQueue = DispatchQueue(label: "DJYusakuImageFetch", qos:.userInteractive)
     private var imageFetchWorkItem : [DispatchWorkItem?] = [DispatchWorkItem?](repeating: nil, count: 25)
+    private var pushed = false
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -109,6 +110,8 @@ extension SearchViewController: UITableViewDataSource {
 extension SearchViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard !(self.pushed) else { return }
+        self.pushed = true
         self.tableView.deselectRow(at: indexPath, animated: false)  // セルの選択を解除
         
         let song = results[indexPath.row]

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -124,20 +124,18 @@ extension SearchViewController: UITableViewDelegate {
         let song = results[indexPath.row]
         let viewController = self.presentingViewController ?? self   // 閉じる対象のViewController
         if ConnectionController.shared.isDJ! {   // 自分がDJのとき
-            PlayerQueue.shared.add(with: song) { [unowned viewController] in
-                viewController.dismiss(animated: true)    // 1曲追加するごとにViewを閉じる
-            }
+            PlayerQueue.shared.add(with: song)
         } else {                                 // 自分がリスナーのとき
             guard ConnectionController.shared.connectedDJ!.state == .connected else { return }
             let songData = try! JSONEncoder().encode(song)
             
             let messageData = try! JSONEncoder().encode(MessageData(desc:  MessageData.DataType.requestSong, value: songData))
             
-            ConnectionController.shared.send(messageData, toPeers: [ConnectionController.shared.connectedDJ!.peerID], with: .unreliable) { [unowned viewController] in
+            ConnectionController.shared.send(messageData, toPeers: [ConnectionController.shared.connectedDJ!.peerID], with: .unreliable) {
                 tableView.cellForRow(at: indexPath)?.selectionStyle = .none
-                viewController.dismiss(animated: true)    // 1曲追加するごとにViewを閉じる
             }
         }
+        viewController.dismiss(animated: true) //1曲追加するごとにViewを閉じる
     }
     
 }

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -23,7 +23,7 @@ class SearchViewController: UIViewController {
     // 画像の取得の際に用いるキュー
     private let imageFetchQueue = DispatchQueue(label: "DJYusakuImageFetch", qos:.userInteractive)
     private var imageFetchWorkItem : [DispatchWorkItem?] = [DispatchWorkItem?](repeating: nil, count: 25)
-    private var pushed = false
+    private var isSongSelected = false
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -60,6 +60,12 @@ class SearchViewController: UIViewController {
             }
             self.storefrontCountryCode = storefrontCountryCode
         }
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        self.isSongSelected = false
     }
     
     override func viewDidDisappear(_ animated: Bool) {
@@ -110,9 +116,10 @@ extension SearchViewController: UITableViewDataSource {
 extension SearchViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard !(self.pushed) else { return }
-        self.pushed = true
         self.tableView.deselectRow(at: indexPath, animated: false)  // セルの選択を解除
+        
+        guard !(self.isSongSelected) else { return }
+        self.isSongSelected = true
         
         let song = results[indexPath.row]
         let viewController = self.presentingViewController ?? self   // 閉じる対象のViewController


### PR DESCRIPTION
## 概要
親機で曲を検索して、めちゃくちゃにセルをタップした時リクエスト画面がぶっ壊れる(skipしても次の曲に行かない、見た目の曲数より曲が入っているため全ての曲をskipしても全てグレーアウトされてしまって先頭の曲に戻らないなど)バグがあったので1回押したら最初に押したセル含め他のセルを押せないようにした。
(バグは最新のmasterでも @tsuu32 の`fix/force-unwrap`でもなりました。)
ちなみに検索画面を開くたびpushedはfalseになるため今後リクエストできなくなる、といった動作は起こらないはず(自分では試しました)

## バグのスクリーンショット
<img src="https://user-images.githubusercontent.com/25448272/72233236-742e0500-3609-11ea-83f5-de2eeec97fe1.PNG" width="200px">

## やってほしいこと
親機の検索画面でめちゃくちゃに様々なセルをタップしてほしいです。

## あと
これがマージされたら`fix/force-unwrap`で追加される予定の曲をsendできなかった時のalertのあとにpushedをfalseにする処理を追加したいです。