### PR TITLE
省電力モードでアニメーション途中で元の画面に戻ったときに画面が暗くなるバグを修正

### DIFF
--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -825,7 +825,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fx4-pT-4uu">
+                            <view userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fx4-pT-4uu">
                                 <rect key="frame" x="40" y="271" width="295" height="280"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="JukeSleeping" translatesAutoresizingMaskIntoConstraints="NO" id="2gp-S6-Snf">

--- a/DJYusaku/BatterySaverViewController.swift
+++ b/DJYusaku/BatterySaverViewController.swift
@@ -68,9 +68,11 @@ class BatterySaverViewController: UIViewController {
         UIScreen.main.brightness = previousScreenBrightness
         UIView.animate(withDuration: 2.0, delay: 1.0, animations: {
             view.alpha = 0.0
-        }, completion: { _ in
-            view.alpha = 0.0
-            UIScreen.main.brightness = 0.0
+        }, completion: { finished in
+            if finished {
+                view.alpha = 0.0
+                UIScreen.main.brightness = 0.0
+            }
         })
     }
     


### PR DESCRIPTION
### やったこと

- 省電力モードでアニメーション途中で元の画面に戻ったときに画面が暗くなるバグを修正
- 省電力モードの表示が出ていてもダブルタップで元の画面に戻れるように

### やってほしいこと
速やかなマージ @amylaseF85 @tsuu32 @bldsky 