### PR TITLE
Apple Musicの契約確認のタイミングをWelcomeViewControllerに変更

### DIFF
--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -625,14 +625,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 29WP3DF4XR;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
 				PRODUCT_NAME = Juke;
 				SWIFT_VERSION = 5.0;
@@ -646,14 +646,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 29WP3DF4XR;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
 				PRODUCT_NAME = Juke;
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -266,13 +266,13 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Logo" translatesAutoresizingMaskIntoConstraints="NO" id="LZr-FI-GlJ">
-                                <rect key="frame" x="87.666666666666686" y="181" width="200" height="200"/>
+                                <rect key="frame" x="87.666666666666686" y="231" width="200" height="100"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="200" id="Zh3-0L-qL5"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="© 2020 Yusaku" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S0h-WO-K7i">
-                                <rect key="frame" x="87.666666666666686" y="385" width="200" height="14.333333333333314"/>
+                                <rect key="frame" x="87.666666666666686" y="335" width="200" height="14.333333333333314"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -328,6 +328,7 @@
                         <outlet property="doneButtonItem" destination="TJq-Z4-zB5" id="qch-i1-thH"/>
                         <outlet property="joinTheSessionButton" destination="RGD-qI-6Bt" id="MBm-Ca-ZIR"/>
                         <outlet property="newSessionButton" destination="90a-jE-PNH" id="Hhq-9f-lpi"/>
+                        <outlet property="tutorialButton" destination="FHg-xT-x4r" id="Jyo-Xh-6Gi"/>
                         <segue destination="2ZU-rh-NCc" kind="show" identifier="goToListenerConnectionSegue" id="lTr-Nx-VCN"/>
                     </connections>
                 </viewController>
@@ -372,7 +373,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Juke allows you to make and play playlists by &quot;requesting&quot; songs to the other who subscribes to Apple Music." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bSx-NQ-Bh4">
-                                <rect key="frame" x="47" y="523" width="281" height="50.333333333333371"/>
+                                <rect key="frame" x="47" y="473" width="281" height="50.333333333333371"/>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -381,19 +382,19 @@
                                 </variation>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="LogoWhite" translatesAutoresizingMaskIntoConstraints="NO" id="Xcd-pM-qNx">
-                                <rect key="frame" x="91.666666666666686" y="311" width="192" height="200"/>
+                                <rect key="frame" x="91.666666666666686" y="361" width="192" height="100"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="192" id="oul-qf-lS9"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome to" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xjw-4N-jZQ">
-                                <rect key="frame" x="91.666666666666686" y="284.66666666666669" width="192" height="38.333333333333314"/>
+                                <rect key="frame" x="91.666666666666686" y="334.66666666666669" width="192" height="38.333333333333314"/>
                                 <fontDescription key="fontDescription" type="system" weight="thin" pointSize="32"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="BorderedAppIcon" translatesAutoresizingMaskIntoConstraints="NO" id="2EG-oP-0Cn">
-                                <rect key="frame" x="130.66666666666666" y="162.66666666666666" width="114" height="113.99999999999997"/>
+                                <rect key="frame" x="130.66666666666666" y="212.66666666666663" width="114" height="114"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="114" id="jcK-ri-F86"/>
                                     <constraint firstAttribute="width" constant="114" id="omu-p7-cfi"/>

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -266,13 +266,13 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Logo" translatesAutoresizingMaskIntoConstraints="NO" id="LZr-FI-GlJ">
-                                <rect key="frame" x="87.666666666666686" y="231" width="200" height="100"/>
+                                <rect key="frame" x="87.666666666666686" y="181" width="200" height="200"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="200" id="Zh3-0L-qL5"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="© 2020 Yusaku" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S0h-WO-K7i">
-                                <rect key="frame" x="87.666666666666686" y="335" width="200" height="14.333333333333314"/>
+                                <rect key="frame" x="87.666666666666686" y="385" width="200" height="14.333333333333314"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -373,7 +373,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Juke allows you to make and play playlists by &quot;requesting&quot; songs to the other who subscribes to Apple Music." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bSx-NQ-Bh4">
-                                <rect key="frame" x="47" y="473" width="281" height="50.333333333333371"/>
+                                <rect key="frame" x="47" y="523" width="281" height="50.333333333333371"/>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -382,19 +382,19 @@
                                 </variation>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="LogoWhite" translatesAutoresizingMaskIntoConstraints="NO" id="Xcd-pM-qNx">
-                                <rect key="frame" x="91.666666666666686" y="361" width="192" height="100"/>
+                                <rect key="frame" x="91.666666666666686" y="311" width="192" height="200"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="192" id="oul-qf-lS9"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome to" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xjw-4N-jZQ">
-                                <rect key="frame" x="91.666666666666686" y="334.66666666666669" width="192" height="38.333333333333314"/>
+                                <rect key="frame" x="91.666666666666686" y="284.66666666666669" width="192" height="38.333333333333314"/>
                                 <fontDescription key="fontDescription" type="system" weight="thin" pointSize="32"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="BorderedAppIcon" translatesAutoresizingMaskIntoConstraints="NO" id="2EG-oP-0Cn">
-                                <rect key="frame" x="130.66666666666666" y="212.66666666666663" width="114" height="114"/>
+                                <rect key="frame" x="130.66666666666666" y="162.66666666666666" width="114" height="113.99999999999997"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="114" id="jcK-ri-F86"/>
                                     <constraint firstAttribute="width" constant="114" id="omu-p7-cfi"/>

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -277,7 +277,7 @@
                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FHg-xT-x4r">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FHg-xT-x4r">
                                 <rect key="frame" x="16" y="638" width="48" height="48"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="48" id="UL1-9W-WBM"/>

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -242,7 +242,7 @@
                                     <color key="titleColor" name="YusakuPinkColor"/>
                                 </state>
                                 <connections>
-                                    <action selector="joinAsDJ:" destination="ypK-t8-Qz5" eventType="touchUpInside" id="Cvb-jF-sgk"/>
+                                    <action selector="newSessionButtonTouchUpInside:" destination="ypK-t8-Qz5" eventType="touchUpInside" id="Cvb-jF-sgk"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RGD-qI-6Bt">
@@ -256,7 +256,7 @@
                                     <color key="titleColor" name="YusakuPinkColor"/>
                                 </state>
                                 <connections>
-                                    <segue destination="2ZU-rh-NCc" kind="show" id="C38-vy-ezJ"/>
+                                    <action selector="joinSessionButtonTouchUpInside:" destination="ypK-t8-Qz5" eventType="touchUpInside" id="0qb-Du-P6b"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="requires Apple Music membership" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QLv-BI-r7q">
@@ -266,13 +266,13 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Logo" translatesAutoresizingMaskIntoConstraints="NO" id="LZr-FI-GlJ">
-                                <rect key="frame" x="87.666666666666686" y="181" width="200" height="200"/>
+                                <rect key="frame" x="87.666666666666686" y="231" width="200" height="100"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="200" id="Zh3-0L-qL5"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="© 2020 Yusaku" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S0h-WO-K7i">
-                                <rect key="frame" x="87.666666666666686" y="385" width="200" height="14.333333333333314"/>
+                                <rect key="frame" x="87.666666666666686" y="335" width="200" height="14.333333333333314"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -328,6 +328,7 @@
                         <outlet property="doneButtonItem" destination="TJq-Z4-zB5" id="qch-i1-thH"/>
                         <outlet property="joinTheSessionButton" destination="RGD-qI-6Bt" id="MBm-Ca-ZIR"/>
                         <outlet property="newSessionButton" destination="90a-jE-PNH" id="Hhq-9f-lpi"/>
+                        <segue destination="2ZU-rh-NCc" kind="show" identifier="goToListenerConnectionSegue" id="lTr-Nx-VCN"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="TWJ-oW-tme" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -371,7 +372,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Juke allows you to make and play playlists by &quot;requesting&quot; songs to the other who subscribes to Apple Music." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bSx-NQ-Bh4">
-                                <rect key="frame" x="47" y="523" width="281" height="50.333333333333371"/>
+                                <rect key="frame" x="47" y="473" width="281" height="50.333333333333371"/>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -380,19 +381,19 @@
                                 </variation>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="LogoWhite" translatesAutoresizingMaskIntoConstraints="NO" id="Xcd-pM-qNx">
-                                <rect key="frame" x="91.666666666666686" y="311" width="192" height="200"/>
+                                <rect key="frame" x="91.666666666666686" y="361" width="192" height="100"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="192" id="oul-qf-lS9"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome to" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xjw-4N-jZQ">
-                                <rect key="frame" x="91.666666666666686" y="284.66666666666669" width="192" height="38.333333333333314"/>
+                                <rect key="frame" x="91.666666666666686" y="334.66666666666669" width="192" height="38.333333333333314"/>
                                 <fontDescription key="fontDescription" type="system" weight="thin" pointSize="32"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="BorderedAppIcon" translatesAutoresizingMaskIntoConstraints="NO" id="2EG-oP-0Cn">
-                                <rect key="frame" x="130.66666666666666" y="162.66666666666666" width="114" height="113.99999999999997"/>
+                                <rect key="frame" x="130.66666666666666" y="212.66666666666663" width="114" height="114"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="114" id="jcK-ri-F86"/>
                                     <constraint firstAttribute="width" constant="114" id="omu-p7-cfi"/>

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -266,13 +266,13 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Logo" translatesAutoresizingMaskIntoConstraints="NO" id="LZr-FI-GlJ">
-                                <rect key="frame" x="87.666666666666686" y="231" width="200" height="100"/>
+                                <rect key="frame" x="87.666666666666686" y="181" width="200" height="200"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="200" id="Zh3-0L-qL5"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="© 2020 Yusaku" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S0h-WO-K7i">
-                                <rect key="frame" x="87.666666666666686" y="335" width="200" height="14.333333333333314"/>
+                                <rect key="frame" x="87.666666666666686" y="385" width="200" height="14.333333333333314"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -372,7 +372,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Juke allows you to make and play playlists by &quot;requesting&quot; songs to the other who subscribes to Apple Music." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bSx-NQ-Bh4">
-                                <rect key="frame" x="47" y="473" width="281" height="50.333333333333371"/>
+                                <rect key="frame" x="47" y="523" width="281" height="50.333333333333371"/>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -381,19 +381,19 @@
                                 </variation>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="LogoWhite" translatesAutoresizingMaskIntoConstraints="NO" id="Xcd-pM-qNx">
-                                <rect key="frame" x="91.666666666666686" y="361" width="192" height="100"/>
+                                <rect key="frame" x="91.666666666666686" y="311" width="192" height="200"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="192" id="oul-qf-lS9"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome to" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xjw-4N-jZQ">
-                                <rect key="frame" x="91.666666666666686" y="334.66666666666669" width="192" height="38.333333333333314"/>
+                                <rect key="frame" x="91.666666666666686" y="284.66666666666669" width="192" height="38.333333333333314"/>
                                 <fontDescription key="fontDescription" type="system" weight="thin" pointSize="32"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="BorderedAppIcon" translatesAutoresizingMaskIntoConstraints="NO" id="2EG-oP-0Cn">
-                                <rect key="frame" x="130.66666666666666" y="212.66666666666663" width="114" height="114"/>
+                                <rect key="frame" x="130.66666666666666" y="162.66666666666666" width="114" height="113.99999999999997"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="114" id="jcK-ri-F86"/>
                                     <constraint firstAttribute="width" constant="114" id="omu-p7-cfi"/>

--- a/DJYusaku/ConnectionController.swift
+++ b/DJYusaku/ConnectionController.swift
@@ -51,8 +51,6 @@ class ConnectionController: NSObject {
             return self.session.connectedPeers.count + 1
         }
     }
-    
-    var canPlayAppleMusic = false
 
     func initialize() {
         if let peerIDData = UserDefaults.standard.data(forKey: UserDefaults.DJYusakuDefaults.ArchivedPeerID) {

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -7,7 +7,6 @@
 //
 
 import UIKit
-import StoreKit
 import MediaPlayer
 
 extension Notification.Name {
@@ -26,7 +25,6 @@ class RequestsViewController: UIViewController {
     static private var isViewAppearedAtLeastOnce: Bool = false
     static private var indexOfNowPlayingItemOnListener: Int = 0
     
-    private let cloudServiceController = SKCloudServiceController()
     private let defaultArtwork : UIImage = UIImage()
     
     override func viewDidLoad() {
@@ -57,16 +55,6 @@ class RequestsViewController: UIViewController {
         let footerView = UIView()
         footerView.frame.size.height = 128
         tableView.tableFooterView = footerView // 空のセルの罫線を消す
-        
-        // Apple Musicライブラリへのアクセス許可の確認
-        SKCloudServiceController.requestAuthorization { status in
-            guard status == .authorized else { return }
-            // Apple Musicの曲が再生可能か確認
-            self.cloudServiceController.requestCapabilities { (capabilities, error) in
-                guard error == nil && capabilities.contains(.musicCatalogPlayback) else { return }
-                ConnectionController.shared.canPlayAppleMusic = true
-            }
-        }
         
         NotificationCenter.default.addObserver(self, selector: #selector(handleRequestsDidUpdate), name: .DJYusakuPlayerQueueDidUpdate, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleNowPlayingItemDidChangeOnDJ), name: .DJYusakuPlayerQueueNowPlayingSongDidChange, object: nil)

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import StoreKit
 import MediaPlayer
 
 extension Notification.Name {
@@ -64,6 +65,13 @@ class RequestsViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(handleButtonStateChange), name: .DJYusakuIsQueueCreatedDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleModalViewDidDisappear), name: .DJYusakuModalViewDidDisappear, object: nil)
         
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        // Apple Musicライブラリへのアクセス許可の確認（何もしない）
+        SKCloudServiceController.requestAuthorization( { _ in } )
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -57,6 +57,9 @@ class RequestsViewController: UIViewController {
         footerView.frame.size.height = 128
         tableView.tableFooterView = footerView // 空のセルの罫線を消す
         
+        // Apple Musicライブラリへのアクセス許可の確認（何もしない）
+        SKCloudServiceController.requestAuthorization( { _ in } )
+        
         NotificationCenter.default.addObserver(self, selector: #selector(handleRequestsDidUpdate), name: .DJYusakuPlayerQueueDidUpdate, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleNowPlayingItemDidChangeOnDJ), name: .DJYusakuPlayerQueueNowPlayingSongDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handlePlaybackStateDidChange), name: .DJYusakuPlayerQueuePlaybackStateDidChange, object: nil)
@@ -65,13 +68,6 @@ class RequestsViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(handleButtonStateChange), name: .DJYusakuIsQueueCreatedDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleModalViewDidDisappear), name: .DJYusakuModalViewDidDisappear, object: nil)
         
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        // Apple Musicライブラリへのアクセス許可の確認（何もしない）
-        SKCloudServiceController.requestAuthorization( { _ in } )
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -48,7 +48,7 @@ class SearchViewController: UIViewController {
             if error != nil {
                 // アラートを表示
                 let alertController = UIAlertController(title:   "Apple Music connection failed".localized,
-                                                        message: "Please check your online status or Apple Music access permission at \"Settings\" app.".localized,
+                                                        message: "Please check your online status.".localized,
                                                         preferredStyle: UIAlertController.Style.alert)
                 let alertButton = UIAlertAction(title: "OK",
                                                 style: UIAlertAction.Style.cancel) { [unowned self] action in

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -51,7 +51,7 @@ class SearchViewController: UIViewController {
                                                         message: "Please check your online status or Apple Music access permission at \"Settings\" app.".localized,
                                                         preferredStyle: UIAlertController.Style.alert)
                 let alertButton = UIAlertAction(title: "OK",
-                                                style: UIAlertAction.Style.cancel) { action in
+                                                style: UIAlertAction.Style.cancel) { [unowned self] action in
                                                     self.dismiss(animated: true)
                 }
                 alertController.addAction(alertButton)

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import StoreKit
 import MultipeerConnectivity
 
 class WelcomeViewController: UIViewController {
@@ -15,6 +16,8 @@ class WelcomeViewController: UIViewController {
     
     @IBOutlet weak var newSessionButton: UIButton!
     @IBOutlet weak var joinTheSessionButton: UIButton!
+    
+    private let cloudServiceController = SKCloudServiceController()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -70,22 +73,42 @@ class WelcomeViewController: UIViewController {
     }
     
     @IBAction func joinAsDJ(_ sender: Any) {
-        if !ConnectionController.shared.canPlayAppleMusic {
-            // アラートを表示
-            let alertController = UIAlertController(title:   "Apple Music membership could not be confirmed".localized,
-                                                    message: "Apple Music songs are not played in this session.".localized,
-                                                    preferredStyle: .alert)
-            let alertButton = UIAlertAction(title: "OK",
-                                            style: .cancel) { action in
-                                                ConnectionController.shared.startDJ()
-                                                self.dismiss(animated: true)
-            }
-            alertController.addAction(alertButton)
-            self.present(alertController, animated: true, completion: nil)
-            return
+        defer {
+            ConnectionController.shared.startDJ()
+            self.dismiss(animated: true, completion: nil)
         }
-        ConnectionController.shared.startDJ()
         
-        self.dismiss(animated: true, completion: nil)
+        // Apple Musicライブラリへのアクセス許可の確認
+        SKCloudServiceController.requestAuthorization { status in
+            guard status == .authorized else { return }
+            // Apple Musicの曲が再生可能か確認
+            self.cloudServiceController.requestCapabilities { [unowned self] (capabilities, error) in
+                guard error == nil else { // なんらかの理由で接続に失敗していたとき
+                    DispatchQueue.main.async {
+                        let alertController = UIAlertController(title: "Apple Music connection failed".localized,
+                                                                message: "Please check your online status.".localized,
+                                                                preferredStyle: .alert)
+                        let alertButton = UIAlertAction(title: "OK",
+                                                        style: .cancel)
+                        alertController.addAction(alertButton)
+                        self.presentingViewController?.present(alertController, animated: true)
+                    }
+                    return
+                }
+                if !capabilities.contains(.musicCatalogPlayback) { // Apple Musicの再生権限がないとき
+                    DispatchQueue.main.async {
+                        let alertController = UIAlertController(title: "Apple Music membership could not be confirmed".localized,
+                                                                message: "Apple Music songs are not played in this session.".localized,
+                                                                preferredStyle: .alert)
+                        let alertButton = UIAlertAction(title: "OK",
+                                                        style: .cancel)
+                        alertController.addAction(alertButton)
+                        self.presentingViewController?.present(alertController, animated: true)
+                    }
+                    return
+                }
+            }
+        }
     }
+    
 }

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -127,7 +127,7 @@ class WelcomeViewController: UIViewController {
     }
     
     @IBAction func joinSessionButtonTouchUpInside(_ sender: Any) {
-        SKCloudServiceController.requestAuthorization { [unowned self] status in
+        SKCloudServiceController.requestAuthorization { [weak self] status in
             guard status == .authorized else {
                 DispatchQueue.main.async {
                     let alertController = UIAlertController(title: "Apple Music authorization failed".localized,
@@ -135,12 +135,12 @@ class WelcomeViewController: UIViewController {
                                                             preferredStyle: .alert)
                     let alertButton = UIAlertAction(title: "OK", style: .cancel)
                     alertController.addAction(alertButton)
-                    self.present(alertController, animated: true)
+                    self?.present(alertController, animated: true)
                 }
                 return
             }
             DispatchQueue.main.async {
-                self.performSegue(withIdentifier: "goToListenerConnectionSegue", sender: nil)
+                self?.performSegue(withIdentifier: "goToListenerConnectionSegue", sender: nil)
             }
         }
     }

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -22,6 +22,10 @@ class WelcomeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        // 同時タップの防止
+        self.newSessionButton.isExclusiveTouch = true
+        self.joinTheSessionButton.isExclusiveTouch = true
+        
         // ナビゲーションバーの見た目を設定
         self.navigationController?.navigationBar.shadowImage = UIImage()    // 下線を消す
         
@@ -55,11 +59,7 @@ class WelcomeViewController: UIViewController {
             self.present(tutorialViewController, animated: true)
         }
         
-        if ConnectionController.shared.isDJ != nil {
-            self.doneButtonItem.isEnabled = true
-        } else {
-            self.doneButtonItem.isEnabled = false
-        }
+        self.doneButtonItem.isEnabled = ConnectionController.shared.isDJ != nil
     }
     
     override func viewDidDisappear(_ animated: Bool) {
@@ -73,7 +73,7 @@ class WelcomeViewController: UIViewController {
     }
     
     @IBAction func newSessionButtonTouchUpInside(_ sender: Any) {
-        SKCloudServiceController.requestAuthorization { [unowned self] status in
+        SKCloudServiceController.requestAuthorization { [weak self] status in
             guard status == .authorized else {
                 DispatchQueue.main.async {
                     let alertController = UIAlertController(title: "Apple Music authorization failed".localized,
@@ -81,7 +81,7 @@ class WelcomeViewController: UIViewController {
                                                             preferredStyle: .alert)
                     let alertButton = UIAlertAction(title: "OK", style: .cancel)
                     alertController.addAction(alertButton)
-                    self.present(alertController, animated: true)
+                    self?.present(alertController, animated: true)
                 }
                 return
             }
@@ -92,17 +92,17 @@ class WelcomeViewController: UIViewController {
                 }
             }
             // Apple Musicの曲が再生可能か確認
-            self.cloudServiceController.requestCapabilities { [unowned self] (capabilities, error) in
+            self?.cloudServiceController.requestCapabilities { [weak self] (capabilities, error) in
                 guard error == nil else { // なんらかの理由で接続に失敗していたとき
                     DispatchQueue.main.async {
                         let alertController = UIAlertController(title: "Apple Music connection failed".localized,
                                                                 message: "Please check your online status.".localized,
                                                                 preferredStyle: .alert)
                         let alertButton = UIAlertAction(title: "OK", style: .cancel) { [unowned self] _ in
-                            self.dismiss(animated: true, completion: nil)
+                            self?.dismiss(animated: true, completion: nil)
                         }
                         alertController.addAction(alertButton)
-                        self.present(alertController, animated: true)
+                        self?.present(alertController, animated: true)
                     }
                     return
                 }
@@ -112,15 +112,15 @@ class WelcomeViewController: UIViewController {
                                                                 message: "Apple Music songs are not played in this session.".localized,
                                                                 preferredStyle: .alert)
                         let alertButton = UIAlertAction(title: "OK", style: .cancel) { [unowned self] _ in
-                            self.dismiss(animated: true, completion: nil)
+                            self?.dismiss(animated: true, completion: nil)
                         }
                         alertController.addAction(alertButton)
-                        self.present(alertController, animated: true)
+                        self?.present(alertController, animated: true)
                     }
                     return
                 }
                 DispatchQueue.main.async {
-                    self.dismiss(animated: true, completion: nil)
+                    self?.dismiss(animated: true, completion: nil)
                 }
             }
         }

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -93,8 +93,8 @@ class WelcomeViewController: UIViewController {
             }
             // Apple Musicの曲が再生可能か確認
             self.cloudServiceController.requestCapabilities { [unowned self] (capabilities, error) in
-                DispatchQueue.main.async {
-                    guard error == nil else { // なんらかの理由で接続に失敗していたとき
+                guard error == nil else { // なんらかの理由で接続に失敗していたとき
+                    DispatchQueue.main.async {
                         let alertController = UIAlertController(title: "Apple Music connection failed".localized,
                                                                 message: "Please check your online status.".localized,
                                                                 preferredStyle: .alert)
@@ -103,9 +103,11 @@ class WelcomeViewController: UIViewController {
                         }
                         alertController.addAction(alertButton)
                         self.present(alertController, animated: true)
-                        return
                     }
-                    if !capabilities.contains(.musicCatalogPlayback) { // Apple Musicの再生権限がないとき
+                    return
+                }
+                if !capabilities.contains(.musicCatalogPlayback) { // Apple Musicの再生権限がないとき
+                    DispatchQueue.main.async {
                         let alertController = UIAlertController(title: "Apple Music membership could not be confirmed".localized,
                                                                 message: "Apple Music songs are not played in this session.".localized,
                                                                 preferredStyle: .alert)
@@ -114,8 +116,10 @@ class WelcomeViewController: UIViewController {
                         }
                         alertController.addAction(alertButton)
                         self.present(alertController, animated: true)
-                        return
                     }
+                    return
+                }
+                DispatchQueue.main.async {
                     self.dismiss(animated: true, completion: nil)
                 }
             }

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -72,7 +72,7 @@ class WelcomeViewController: UIViewController {
         self.dismiss(animated: true, completion: nil)
     }
     
-    @IBAction func joinAsDJ(_ sender: Any) {
+    @IBAction func newSessionButtonTouchUpInside(_ sender: Any) {
         SKCloudServiceController.requestAuthorization { [unowned self] status in
             guard status == .authorized else {
                 DispatchQueue.main.async {
@@ -118,6 +118,24 @@ class WelcomeViewController: UIViewController {
                     }
                     self.dismiss(animated: true, completion: nil)
                 }
+            }
+        }
+    }
+    
+    @IBAction func joinSessionButtonTouchUpInside(_ sender: Any) {        SKCloudServiceController.requestAuthorization { [unowned self] status in
+            guard status == .authorized else {
+                DispatchQueue.main.async {
+                    let alertController = UIAlertController(title: "Apple Music authorization failed".localized,
+                                                            message: "Please check your Apple Music access permission at \"Settings\" app.".localized,
+                                                            preferredStyle: .alert)
+                    let alertButton = UIAlertAction(title: "OK", style: .cancel)
+                    alertController.addAction(alertButton)
+                    self.present(alertController, animated: true)
+                }
+                return
+            }
+            DispatchQueue.main.async {
+                self.performSegue(withIdentifier: "goToListenerConnectionSegue", sender: nil)
             }
         }
     }

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -82,7 +82,7 @@ class WelcomeViewController: UIViewController {
         SKCloudServiceController.requestAuthorization { status in
             guard status == .authorized else { return }
             // Apple Musicの曲が再生可能か確認
-            self.cloudServiceController.requestCapabilities { [unowned self] (capabilities, error) in
+            self.cloudServiceController.requestCapabilities { [weak self] (capabilities, error) in
                 guard error == nil else { // なんらかの理由で接続に失敗していたとき
                     DispatchQueue.main.async {
                         let alertController = UIAlertController(title: "Apple Music connection failed".localized,
@@ -91,7 +91,7 @@ class WelcomeViewController: UIViewController {
                         let alertButton = UIAlertAction(title: "OK",
                                                         style: .cancel)
                         alertController.addAction(alertButton)
-                        self.presentingViewController?.present(alertController, animated: true)
+                        self?.presentingViewController?.present(alertController, animated: true)
                     }
                     return
                 }
@@ -103,7 +103,7 @@ class WelcomeViewController: UIViewController {
                         let alertButton = UIAlertAction(title: "OK",
                                                         style: .cancel)
                         alertController.addAction(alertButton)
-                        self.presentingViewController?.present(alertController, animated: true)
+                        self?.presentingViewController?.present(alertController, animated: true)
                     }
                     return
                 }

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -16,6 +16,7 @@ class WelcomeViewController: UIViewController {
     
     @IBOutlet weak var newSessionButton: UIButton!
     @IBOutlet weak var joinTheSessionButton: UIButton!
+    @IBOutlet weak var tutorialButton: UIButton!
     
     private let cloudServiceController = SKCloudServiceController()
     
@@ -25,6 +26,7 @@ class WelcomeViewController: UIViewController {
         // 同時タップの防止
         self.newSessionButton.isExclusiveTouch     = true
         self.joinTheSessionButton.isExclusiveTouch = true
+        self.tutorialButton.isExclusiveTouch       = true
         
         // ナビゲーションバーの見た目を設定
         self.navigationController?.navigationBar.shadowImage = UIImage()    // 下線を消す
@@ -49,6 +51,7 @@ class WelcomeViewController: UIViewController {
         
         self.newSessionButton.isEnabled     = true
         self.joinTheSessionButton.isEnabled = true
+        self.tutorialButton.isEnabled       = true
         
         // 初回起動の際にはTutorialViewControllerを表示する
         let isLaunchedAtLeastOnce = UserDefaults.standard.bool(forKey: UserDefaults.DJYusakuDefaults.IsLaunchedAtLeastOnce)
@@ -78,6 +81,7 @@ class WelcomeViewController: UIViewController {
     @IBAction func newSessionButtonTouchUpInside(_ sender: Any) {
         self.newSessionButton.isEnabled     = false
         self.joinTheSessionButton.isEnabled = false
+        self.tutorialButton.isEnabled       = false
 
         SKCloudServiceController.requestAuthorization { [weak self] status in
             guard status == .authorized else {
@@ -90,6 +94,7 @@ class WelcomeViewController: UIViewController {
                     self?.present(alertController, animated: true)
                     self?.newSessionButton.isEnabled     = true
                     self?.joinTheSessionButton.isEnabled = true
+                    self?.tutorialButton.isEnabled       = true
                 }
                 return
             }
@@ -109,6 +114,7 @@ class WelcomeViewController: UIViewController {
                         let alertButton = UIAlertAction(title: "OK", style: .cancel) { [unowned self] _ in
                             self?.newSessionButton.isEnabled     = true
                             self?.joinTheSessionButton.isEnabled = true
+                            self?.tutorialButton.isEnabled       = true
                             self?.dismiss(animated: true, completion: nil)
                         }
                         alertController.addAction(alertButton)
@@ -124,6 +130,7 @@ class WelcomeViewController: UIViewController {
                         let alertButton = UIAlertAction(title: "OK", style: .cancel) { [unowned self] _ in
                             self?.newSessionButton.isEnabled     = true
                             self?.joinTheSessionButton.isEnabled = true
+                            self?.tutorialButton.isEnabled       = true
                             self?.dismiss(animated: true, completion: nil)
                         }
                         alertController.addAction(alertButton)
@@ -134,6 +141,7 @@ class WelcomeViewController: UIViewController {
                 DispatchQueue.main.async {
                     self?.newSessionButton.isEnabled     = true
                     self?.joinTheSessionButton.isEnabled = true
+                    self?.tutorialButton.isEnabled       = true
                     self?.dismiss(animated: true, completion: nil)
                 }
             }
@@ -143,6 +151,7 @@ class WelcomeViewController: UIViewController {
     @IBAction func joinSessionButtonTouchUpInside(_ sender: Any) {
         self.newSessionButton.isEnabled     = false
         self.joinTheSessionButton.isEnabled = false
+        self.tutorialButton.isEnabled       = false
 
         SKCloudServiceController.requestAuthorization { [weak self] status in
             guard status == .authorized else {
@@ -154,6 +163,7 @@ class WelcomeViewController: UIViewController {
                     alertController.addAction(alertButton)
                     self?.newSessionButton.isEnabled     = true
                     self?.joinTheSessionButton.isEnabled = true
+                    self?.tutorialButton.isEnabled       = true
                     self?.present(alertController, animated: true)
                 }
                 return
@@ -161,6 +171,7 @@ class WelcomeViewController: UIViewController {
             DispatchQueue.main.async {
                 self?.newSessionButton.isEnabled     = true
                 self?.joinTheSessionButton.isEnabled = true
+                self?.tutorialButton.isEnabled       = true
                 self?.performSegue(withIdentifier: "goToListenerConnectionSegue", sender: nil)
             }
         }

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -73,7 +73,6 @@ class WelcomeViewController: UIViewController {
     }
     
     @IBAction func joinAsDJ(_ sender: Any) {
-        
         SKCloudServiceController.requestAuthorization { [unowned self] status in
             guard status == .authorized else {
                 DispatchQueue.main.async {
@@ -99,7 +98,7 @@ class WelcomeViewController: UIViewController {
                         let alertController = UIAlertController(title: "Apple Music connection failed".localized,
                                                                 message: "Please check your online status.".localized,
                                                                 preferredStyle: .alert)
-                        let alertButton = UIAlertAction(title: "OK", style: .cancel) { _ in
+                        let alertButton = UIAlertAction(title: "OK", style: .cancel) { [unowned self] _ in
                             self.dismiss(animated: true, completion: nil)
                         }
                         alertController.addAction(alertButton)
@@ -110,7 +109,7 @@ class WelcomeViewController: UIViewController {
                         let alertController = UIAlertController(title: "Apple Music membership could not be confirmed".localized,
                                                                 message: "Apple Music songs are not played in this session.".localized,
                                                                 preferredStyle: .alert)
-                        let alertButton = UIAlertAction(title: "OK", style: .cancel) { _ in
+                        let alertButton = UIAlertAction(title: "OK", style: .cancel) { [unowned self] _ in
                             self.dismiss(animated: true, completion: nil)
                         }
                         alertController.addAction(alertButton)

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -80,10 +80,7 @@ class WelcomeViewController: UIViewController {
                     let alertController = UIAlertController(title: "Apple Music authorization failed".localized,
                                                             message: "Please check your Apple Music access permission at \"Settings\" app.".localized,
                                                             preferredStyle: .alert)
-                    let alertButton = UIAlertAction(title: "OK",
-                                                    style: .cancel) { _ in
-                        NotificationCenter.default.post(name: .DJYusakuModalViewDidDisappear, object: nil)
-                    }
+                    let alertButton = UIAlertAction(title: "OK", style: .cancel)
                     alertController.addAction(alertButton)
                     self.present(alertController, animated: true)
                 }
@@ -93,37 +90,36 @@ class WelcomeViewController: UIViewController {
             defer {
                 DispatchQueue.main.async {
                     ConnectionController.shared.startDJ()
-                    self.dismiss(animated: true, completion: nil)
                 }
             }
             // Apple Musicの曲が再生可能か確認
-            self.cloudServiceController.requestCapabilities { (capabilities, error) in
+            self.cloudServiceController.requestCapabilities { [unowned self] (capabilities, error) in
                 DispatchQueue.main.async {
-                    guard let rootViewController = (UIApplication.shared.windows.filter{$0.isKeyWindow}.first)?.rootViewController else { return }
                     guard error == nil else { // なんらかの理由で接続に失敗していたとき
                         let alertController = UIAlertController(title: "Apple Music connection failed".localized,
                                                                 message: "Please check your online status.".localized,
                                                                 preferredStyle: .alert)
                         let alertButton = UIAlertAction(title: "OK",
                                                         style: .cancel) { _ in
-                            NotificationCenter.default.post(name: .DJYusakuModalViewDidDisappear, object: nil)
+                            self.dismiss(animated: true, completion: nil)
                         }
                         alertController.addAction(alertButton)
-                        rootViewController.present(alertController, animated: true)
+                        self.present(alertController, animated: true)
                         return
                     }
-                    if !capabilities.contains(.musicCatalogPlayback) { // Apple Musicの再生権限がないとき
+                    if capabilities.contains(.musicCatalogPlayback) { // Apple Musicの再生権限がないとき
                         let alertController = UIAlertController(title: "Apple Music membership could not be confirmed".localized,
                                                                 message: "Apple Music songs are not played in this session.".localized,
                                                                 preferredStyle: .alert)
                         let alertButton = UIAlertAction(title: "OK",
                                                         style: .cancel) { _ in
-                            NotificationCenter.default.post(name: .DJYusakuModalViewDidDisappear, object: nil)
+                            self.dismiss(animated: true, completion: nil)
                         }
                         alertController.addAction(alertButton)
-                        rootViewController.present(alertController, animated: true)
+                        self.present(alertController, animated: true)
                         return
                     }
+                    self.dismiss(animated: true, completion: nil)
                 }
             }
         }

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -122,7 +122,8 @@ class WelcomeViewController: UIViewController {
         }
     }
     
-    @IBAction func joinSessionButtonTouchUpInside(_ sender: Any) {        SKCloudServiceController.requestAuthorization { [unowned self] status in
+    @IBAction func joinSessionButtonTouchUpInside(_ sender: Any) {
+        SKCloudServiceController.requestAuthorization { [unowned self] status in
             guard status == .authorized else {
                 DispatchQueue.main.async {
                     let alertController = UIAlertController(title: "Apple Music authorization failed".localized,

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -112,9 +112,6 @@ class WelcomeViewController: UIViewController {
                                                                 message: "Please check your online status.".localized,
                                                                 preferredStyle: .alert)
                         let alertButton = UIAlertAction(title: "OK", style: .cancel) { [unowned self] _ in
-                            self?.newSessionButton.isEnabled     = true
-                            self?.joinTheSessionButton.isEnabled = true
-                            self?.tutorialButton.isEnabled       = true
                             self?.dismiss(animated: true, completion: nil)
                         }
                         alertController.addAction(alertButton)
@@ -128,9 +125,6 @@ class WelcomeViewController: UIViewController {
                                                                 message: "Apple Music songs are not played in this session.".localized,
                                                                 preferredStyle: .alert)
                         let alertButton = UIAlertAction(title: "OK", style: .cancel) { [unowned self] _ in
-                            self?.newSessionButton.isEnabled     = true
-                            self?.joinTheSessionButton.isEnabled = true
-                            self?.tutorialButton.isEnabled       = true
                             self?.dismiss(animated: true, completion: nil)
                         }
                         alertController.addAction(alertButton)
@@ -139,9 +133,6 @@ class WelcomeViewController: UIViewController {
                     return
                 }
                 DispatchQueue.main.async {
-                    self?.newSessionButton.isEnabled     = true
-                    self?.joinTheSessionButton.isEnabled = true
-                    self?.tutorialButton.isEnabled       = true
                     self?.dismiss(animated: true, completion: nil)
                 }
             }
@@ -169,9 +160,6 @@ class WelcomeViewController: UIViewController {
                 return
             }
             DispatchQueue.main.async {
-                self?.newSessionButton.isEnabled     = true
-                self?.joinTheSessionButton.isEnabled = true
-                self?.tutorialButton.isEnabled       = true
                 self?.performSegue(withIdentifier: "goToListenerConnectionSegue", sender: nil)
             }
         }

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -82,30 +82,33 @@ class WelcomeViewController: UIViewController {
         SKCloudServiceController.requestAuthorization { status in
             guard status == .authorized else { return }
             // Apple Musicの曲が再生可能か確認
-            self.cloudServiceController.requestCapabilities { [weak self] (capabilities, error) in
-                guard error == nil else { // なんらかの理由で接続に失敗していたとき
-                    DispatchQueue.main.async {
+            self.cloudServiceController.requestCapabilities { (capabilities, error) in
+                DispatchQueue.main.async {
+                    guard let rootViewController = (UIApplication.shared.windows.filter{$0.isKeyWindow}.first)?.rootViewController else { return }
+                    guard error == nil else { // なんらかの理由で接続に失敗していたとき
                         let alertController = UIAlertController(title: "Apple Music connection failed".localized,
                                                                 message: "Please check your online status.".localized,
                                                                 preferredStyle: .alert)
                         let alertButton = UIAlertAction(title: "OK",
-                                                        style: .cancel)
+                                                        style: .cancel) { _ in
+                            NotificationCenter.default.post(name: .DJYusakuModalViewDidDisappear, object: nil)
+                        }
                         alertController.addAction(alertButton)
-                        self?.presentingViewController?.present(alertController, animated: true)
+                        rootViewController.present(alertController, animated: true)
+                        return
                     }
-                    return
-                }
-                if !capabilities.contains(.musicCatalogPlayback) { // Apple Musicの再生権限がないとき
-                    DispatchQueue.main.async {
+                    if !capabilities.contains(.musicCatalogPlayback) { // Apple Musicの再生権限がないとき
                         let alertController = UIAlertController(title: "Apple Music membership could not be confirmed".localized,
                                                                 message: "Apple Music songs are not played in this session.".localized,
                                                                 preferredStyle: .alert)
                         let alertButton = UIAlertAction(title: "OK",
-                                                        style: .cancel)
+                                                        style: .cancel) { _ in
+                            NotificationCenter.default.post(name: .DJYusakuModalViewDidDisappear, object: nil)
+                        }
                         alertController.addAction(alertButton)
-                        self?.presentingViewController?.present(alertController, animated: true)
+                        rootViewController.present(alertController, animated: true)
+                        return
                     }
-                    return
                 }
             }
         }

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -99,20 +99,18 @@ class WelcomeViewController: UIViewController {
                         let alertController = UIAlertController(title: "Apple Music connection failed".localized,
                                                                 message: "Please check your online status.".localized,
                                                                 preferredStyle: .alert)
-                        let alertButton = UIAlertAction(title: "OK",
-                                                        style: .cancel) { _ in
+                        let alertButton = UIAlertAction(title: "OK", style: .cancel) { _ in
                             self.dismiss(animated: true, completion: nil)
                         }
                         alertController.addAction(alertButton)
                         self.present(alertController, animated: true)
                         return
                     }
-                    if capabilities.contains(.musicCatalogPlayback) { // Apple Musicの再生権限がないとき
+                    if !capabilities.contains(.musicCatalogPlayback) { // Apple Musicの再生権限がないとき
                         let alertController = UIAlertController(title: "Apple Music membership could not be confirmed".localized,
                                                                 message: "Apple Music songs are not played in this session.".localized,
                                                                 preferredStyle: .alert)
-                        let alertButton = UIAlertAction(title: "OK",
-                                                        style: .cancel) { _ in
+                        let alertButton = UIAlertAction(title: "OK", style: .cancel) { _ in
                             self.dismiss(animated: true, completion: nil)
                         }
                         alertController.addAction(alertButton)

--- a/DJYusaku/WelcomeViewController.swift
+++ b/DJYusaku/WelcomeViewController.swift
@@ -23,7 +23,7 @@ class WelcomeViewController: UIViewController {
         super.viewDidLoad()
         
         // 同時タップの防止
-        self.newSessionButton.isExclusiveTouch = true
+        self.newSessionButton.isExclusiveTouch     = true
         self.joinTheSessionButton.isExclusiveTouch = true
         
         // ナビゲーションバーの見た目を設定
@@ -46,6 +46,9 @@ class WelcomeViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        
+        self.newSessionButton.isEnabled     = true
+        self.joinTheSessionButton.isEnabled = true
         
         // 初回起動の際にはTutorialViewControllerを表示する
         let isLaunchedAtLeastOnce = UserDefaults.standard.bool(forKey: UserDefaults.DJYusakuDefaults.IsLaunchedAtLeastOnce)
@@ -73,6 +76,9 @@ class WelcomeViewController: UIViewController {
     }
     
     @IBAction func newSessionButtonTouchUpInside(_ sender: Any) {
+        self.newSessionButton.isEnabled     = false
+        self.joinTheSessionButton.isEnabled = false
+
         SKCloudServiceController.requestAuthorization { [weak self] status in
             guard status == .authorized else {
                 DispatchQueue.main.async {
@@ -82,6 +88,8 @@ class WelcomeViewController: UIViewController {
                     let alertButton = UIAlertAction(title: "OK", style: .cancel)
                     alertController.addAction(alertButton)
                     self?.present(alertController, animated: true)
+                    self?.newSessionButton.isEnabled     = true
+                    self?.joinTheSessionButton.isEnabled = true
                 }
                 return
             }
@@ -99,6 +107,8 @@ class WelcomeViewController: UIViewController {
                                                                 message: "Please check your online status.".localized,
                                                                 preferredStyle: .alert)
                         let alertButton = UIAlertAction(title: "OK", style: .cancel) { [unowned self] _ in
+                            self?.newSessionButton.isEnabled     = true
+                            self?.joinTheSessionButton.isEnabled = true
                             self?.dismiss(animated: true, completion: nil)
                         }
                         alertController.addAction(alertButton)
@@ -112,6 +122,8 @@ class WelcomeViewController: UIViewController {
                                                                 message: "Apple Music songs are not played in this session.".localized,
                                                                 preferredStyle: .alert)
                         let alertButton = UIAlertAction(title: "OK", style: .cancel) { [unowned self] _ in
+                            self?.newSessionButton.isEnabled     = true
+                            self?.joinTheSessionButton.isEnabled = true
                             self?.dismiss(animated: true, completion: nil)
                         }
                         alertController.addAction(alertButton)
@@ -120,6 +132,8 @@ class WelcomeViewController: UIViewController {
                     return
                 }
                 DispatchQueue.main.async {
+                    self?.newSessionButton.isEnabled     = true
+                    self?.joinTheSessionButton.isEnabled = true
                     self?.dismiss(animated: true, completion: nil)
                 }
             }
@@ -127,6 +141,9 @@ class WelcomeViewController: UIViewController {
     }
     
     @IBAction func joinSessionButtonTouchUpInside(_ sender: Any) {
+        self.newSessionButton.isEnabled     = false
+        self.joinTheSessionButton.isEnabled = false
+
         SKCloudServiceController.requestAuthorization { [weak self] status in
             guard status == .authorized else {
                 DispatchQueue.main.async {
@@ -135,11 +152,15 @@ class WelcomeViewController: UIViewController {
                                                             preferredStyle: .alert)
                     let alertButton = UIAlertAction(title: "OK", style: .cancel)
                     alertController.addAction(alertButton)
+                    self?.newSessionButton.isEnabled     = true
+                    self?.joinTheSessionButton.isEnabled = true
                     self?.present(alertController, animated: true)
                 }
                 return
             }
             DispatchQueue.main.async {
+                self?.newSessionButton.isEnabled     = true
+                self?.joinTheSessionButton.isEnabled = true
                 self?.performSegue(withIdentifier: "goToListenerConnectionSegue", sender: nil)
             }
         }

--- a/DJYusaku/en.lproj/Localizable.strings
+++ b/DJYusaku/en.lproj/Localizable.strings
@@ -9,12 +9,13 @@
 // PlayerQueue.swift
 "Request failed" = "Request failed";
 "Queue insertion failed. Try again." = "Queue insertion failed. Try again.";
-"Queue insertion failed. Try again." = "Queue insertion failed. Try again.";
 "Queue deletion failed. Try again." = "Queue deletion failed. Try again.";
 "Move failed" = "Move failed";
 "Swap failed. Try again." = "Swap failed. Try again.";
 
 // RequestsViewController.swift
+"Apple Music authorization failed" = "Apple Music authorization failed";
+"Please check your Apple Music access permission at \"Settings\" app." = "Please check your Apple Music access permission at \"Settings\" app.";
 "Battery Saver Mode" = "Battery Saver Mode";
 "To exit battery saver mode, double-tap the screen." = "To exit battery saver mode, double-tap the screen.";
 
@@ -31,6 +32,7 @@
 "You" = "You";
 
 // WelcomeViewController.swift
+"Please check your online status." = "Please check your online status.";
 "Apple Music membership could not be confirmed" = "Apple Music membership could not be confirmed";
 "Apple Music songs are not played in this session." = "Apple Music songs are not played in this session.";
 

--- a/DJYusaku/en.lproj/Localizable.strings
+++ b/DJYusaku/en.lproj/Localizable.strings
@@ -21,7 +21,7 @@
 
 // SearchViewController.swift
 "Apple Music connection failed" = "Apple Music connection failed";
-"Please check your online status or Apple Music access permission at \"Settings\" app." = "Please check your online status or Apple Music access permission at \"Settings\" app.";
+"Please check your online status." = "Please check your online status.";
 "Request failed" = "Request failed";
 "Please check your connection status to session master." = "Please check your connection status to session master.";
 
@@ -32,7 +32,6 @@
 "You" = "You";
 
 // WelcomeViewController.swift
-"Please check your online status." = "Please check your online status.";
 "Apple Music membership could not be confirmed" = "Apple Music membership could not be confirmed";
 "Apple Music songs are not played in this session." = "Apple Music songs are not played in this session.";
 

--- a/DJYusaku/ja.lproj/Localizable.strings
+++ b/DJYusaku/ja.lproj/Localizable.strings
@@ -30,6 +30,7 @@
 "You" = "あなた";
 
 // WelcomeViewController.swift
+"Please check your online status." = "インターネットの状態を確認してください。";
 "Apple Music membership could not be confirmed" = "Apple Musicのメンバーシップを確認できませんでした";
 "Apple Music songs are not played in this session." = "このセッションではApple Musicの楽曲は再生されません。";
 

--- a/DJYusaku/ja.lproj/Localizable.strings
+++ b/DJYusaku/ja.lproj/Localizable.strings
@@ -21,7 +21,7 @@
 
 // SearchViewController.swift
 "Apple Music connection failed" = "Apple Musicとの接続に失敗しました";
-"Please check your online status or Apple Music access permission at \"Settings\" app." = "インターネットの状態または「設定」アプリでApple Musicの許可を確認してください。";
+"Please check your online status." = "インターネットの状態を確認してください。";
 "Request failed" = "リクエストに失敗しました";
 "Please check your connection status to session master." = "親機との接続状況を確認してください。";
 
@@ -32,7 +32,6 @@
 "You" = "あなた";
 
 // WelcomeViewController.swift
-"Please check your online status." = "インターネットの状態を確認してください。";
 "Apple Music membership could not be confirmed" = "Apple Musicのメンバーシップを確認できませんでした";
 "Apple Music songs are not played in this session." = "このセッションではApple Musicの楽曲は再生されません。";
 

--- a/DJYusaku/ja.lproj/Localizable.strings
+++ b/DJYusaku/ja.lproj/Localizable.strings
@@ -14,6 +14,8 @@
 "Swap failed. Try again." = "曲の入れ替えに失敗しました。時間をおいて再度試してください。";
 
 // RequestsViewController.swift
+"Apple Music authorization failed" = "Apple Musicへのアクセスに失敗しました";
+"Please check your Apple Music access permission at \"Settings\" app." = "「設定」アプリでApple Musicの許可を確認してください。";
 "Battery Saver Mode" = "省電力モード";
 "To exit battery saver mode, double-tap the screen." = "画面をダブルタップすると、省電力モードを終了します。";
 


### PR DESCRIPTION
#143 のリベンジ

### やったこと

WelcomeViewContollerの「新規セッション」ボタンを押したときに
- SKCloudServiceControllerがエラーを返す場合
  - ここではオンライン状態が怪しい時だと断定している
- Apple Musicの契約が確認できない場合
にその旨をアラートで表示する（なお、アラートの表示優先度は前者＞後者にしている）

手元のiPhone XS/iPad Pro 10.5"で動作確認済み

### やってほしいこと

オンライン状態やApple Musicのログイン状態に応じてアラートが出るかどうかの動作確認（特に、 @tsuu32 の環境で落ちないか）