### PR TITLE
TableViewCellで意図しない画像が入ることを防ぐ

### DIFF
--- a/DJYusaku/ListenerConnectableDJsTableViewCell.swift
+++ b/DJYusaku/ListenerConnectableDJsTableViewCell.swift
@@ -14,6 +14,8 @@ class ListenerConnectableDJsTableViewCell: UITableViewCell {
     @IBOutlet weak var djImageView: UIImageView!
     @IBOutlet weak var numberOfParticipantsLabel: UILabel!
     
+    var djImageUrl: URL?
+
     override func awakeFromNib() {
         super.awakeFromNib()
         

--- a/DJYusaku/ListenerConnectionViewController.swift
+++ b/DJYusaku/ListenerConnectionViewController.swift
@@ -53,12 +53,18 @@ extension ListenerConnectionViewController: UITableViewDataSource {
         if let profile = ConnectionController.shared.peerProfileCorrespondence[djPeerID] {
             cell.djName?.text = profile.name
 
+            if cell.djImageUrl != profile.imageUrl {
+                cell.djImageView.image = nil
+            }
+            cell.djImageUrl = profile.imageUrl
             DispatchQueue.global().async {
                 if let imageUrl = profile.imageUrl {
                     DJImage = CachedImage.fetch(url: imageUrl)
                 }
                 DispatchQueue.main.async {
-                    cell.djImageView.image = DJImage ?? UIImage(named: "TemporarySingleColored")
+                    if let cell = self.tableView.cellForRow(at: indexPath) as? ListenerConnectableDJsTableViewCell {
+                        cell.djImageView.image = DJImage ?? UIImage(named: "TemporarySingleColored")
+                    }
                 }
             }
         } else {

--- a/DJYusaku/ListenerConnectionViewController.swift
+++ b/DJYusaku/ListenerConnectionViewController.swift
@@ -48,7 +48,6 @@ extension ListenerConnectionViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "ListenerConnectableDJsTableViewCell", for: indexPath) as! ListenerConnectableDJsTableViewCell
-        var DJImage: UIImage?
         let djPeerID = ConnectionController.shared.connectableDJs[indexPath.row]
         if let profile = ConnectionController.shared.peerProfileCorrespondence[djPeerID] {
             cell.djName?.text = profile.name
@@ -57,15 +56,17 @@ extension ListenerConnectionViewController: UITableViewDataSource {
                 cell.djImageView.image = nil
             }
             cell.djImageUrl = profile.imageUrl
-            DispatchQueue.global().async {
-                if let imageUrl = profile.imageUrl {
-                    DJImage = CachedImage.fetch(url: imageUrl)
-                }
-                DispatchQueue.main.async {
-                    if let cell = self.tableView.cellForRow(at: indexPath) as? ListenerConnectableDJsTableViewCell {
-                        cell.djImageView.image = DJImage ?? UIImage(named: "TemporarySingleColored")
+            if let imageUrl = profile.imageUrl {
+                DispatchQueue.global().async {
+                    let image = CachedImage.fetch(url: imageUrl)
+                    DispatchQueue.main.async {
+                        if let cell = self.tableView.cellForRow(at: indexPath) as? ListenerConnectableDJsTableViewCell {
+                            cell.djImageView.image = image ?? UIImage(named: "TemporarySingleColored")
+                        }
                     }
                 }
+            } else {
+                cell.djImageView.image = UIImage(named: "TemporarySingleColored")
             }
         } else {
             cell.djName?.text = djPeerID.displayName

--- a/DJYusaku/MemberTableViewCell.swift
+++ b/DJYusaku/MemberTableViewCell.swift
@@ -14,6 +14,8 @@ class MemberTableViewCell: UITableViewCell {
     @IBOutlet weak var peerName: UILabel!
     @IBOutlet weak var statusView: UIView!
     
+    var peerImageUrl: URL?
+
     override func awakeFromNib() {
         super.awakeFromNib()
         

--- a/DJYusaku/MemberViewController.swift
+++ b/DJYusaku/MemberViewController.swift
@@ -158,7 +158,6 @@ extension MemberViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell  = tableView.dequeueReusableCell(withIdentifier: "MemberTableViewCell", for: indexPath) as! MemberTableViewCell
         guard let isDJ = ConnectionController.shared.isDJ else { return cell }
-        var listenerImage: UIImage?
         if indexPath.row == 0 && !isDJ { // 自分自身（子機）
             let profile = DefaultsController.shared.profile
             cell.peerName.text = profile.name
@@ -167,31 +166,35 @@ extension MemberViewController: UITableViewDataSource {
                 cell.peerImageView.image = nil
             }
             cell.peerImageUrl = profile.imageUrl
-            DispatchQueue.global().async {
-                if let imageUrl = profile.imageUrl {
-                    listenerImage = CachedImage.fetch(url: imageUrl)
-                }
-                DispatchQueue.main.async {
-                    if let cell = self.tableView.cellForRow(at: indexPath) as? MemberTableViewCell {
-                        cell.peerImageView.image = listenerImage ?? UIImage(named: "TemporarySingleColored")
-                        cell.peerImageView.setNeedsLayout()
+            if let imageUrl = profile.imageUrl {
+                DispatchQueue.global().async {
+                    let image = CachedImage.fetch(url: imageUrl)
+                    DispatchQueue.main.async {
+                        if let cell = self.tableView.cellForRow(at: indexPath) as? MemberTableViewCell {
+                            cell.peerImageView.image = image ?? UIImage(named: "TemporarySingleColored")
+                            cell.peerImageView.setNeedsLayout()
+                        }
                     }
                 }
+            } else {
+                cell.peerImageView.image = UIImage(named: "TemporarySingleColored")
             }
         } else { // 自分以外の子機
             if let profile = ConnectionController.shared.peerProfileCorrespondence[self.listeners[indexPath.row]] {
                 cell.peerName.text = profile.name
                 cell.statusView.isHidden = true
-                DispatchQueue.global().async {
-                    if let imageUrl = profile.imageUrl {
-                        listenerImage = CachedImage.fetch(url: imageUrl)
-                    }
-                    DispatchQueue.main.async {
-                        if let cell = self.tableView.cellForRow(at: indexPath) as? MemberTableViewCell {
-                            cell.peerImageView.image = listenerImage ?? UIImage(named: "TemporarySingleColored")
-                            cell.peerImageView.setNeedsLayout()
+                if let imageUrl = profile.imageUrl {
+                    DispatchQueue.global().async {
+                        let image = CachedImage.fetch(url: imageUrl)
+                        DispatchQueue.main.async {
+                            if let cell = self.tableView.cellForRow(at: indexPath) as? MemberTableViewCell {
+                                cell.peerImageView.image = image ?? UIImage(named: "TemporarySingleColored")
+                                cell.peerImageView.setNeedsLayout()
+                            }
                         }
                     }
+                } else {
+                    cell.peerImageView.image = UIImage(named: "TemporarySingleColored")
                 }
             } else { // このリスナーのprofileをまだ受け取ってないとき
                 cell.peerName.text = self.listeners[indexPath.row].displayName

--- a/DJYusaku/MemberViewController.swift
+++ b/DJYusaku/MemberViewController.swift
@@ -163,13 +163,19 @@ extension MemberViewController: UITableViewDataSource {
             let profile = DefaultsController.shared.profile
             cell.peerName.text = profile.name
             cell.statusView.isHidden = false
+            if cell.peerImageUrl != profile.imageUrl {
+                cell.peerImageView.image = nil
+            }
+            cell.peerImageUrl = profile.imageUrl
             DispatchQueue.global().async {
                 if let imageUrl = profile.imageUrl {
                     listenerImage = CachedImage.fetch(url: imageUrl)
                 }
                 DispatchQueue.main.async {
-                    cell.peerImageView.image = listenerImage ?? UIImage(named: "TemporarySingleColored")
-                    cell.peerImageView.setNeedsLayout()
+                    if let cell = self.tableView.cellForRow(at: indexPath) as? MemberTableViewCell {
+                        cell.peerImageView.image = listenerImage ?? UIImage(named: "TemporarySingleColored")
+                        cell.peerImageView.setNeedsLayout()
+                    }
                 }
             }
         } else { // 自分以外の子機
@@ -181,8 +187,10 @@ extension MemberViewController: UITableViewDataSource {
                         listenerImage = CachedImage.fetch(url: imageUrl)
                     }
                     DispatchQueue.main.async {
-                        cell.peerImageView.image = listenerImage ?? UIImage(named: "TemporarySingleColored")
-                        cell.peerImageView.setNeedsLayout()
+                        if let cell = self.tableView.cellForRow(at: indexPath) as? MemberTableViewCell {
+                            cell.peerImageView.image = listenerImage ?? UIImage(named: "TemporarySingleColored")
+                            cell.peerImageView.setNeedsLayout()
+                        }
                     }
                 }
             } else { // このリスナーのprofileをまだ受け取ってないとき

--- a/DJYusaku/RequestsMusicTableViewCell.swift
+++ b/DJYusaku/RequestsMusicTableViewCell.swift
@@ -16,6 +16,9 @@ class RequestsMusicTableViewCell: UITableViewCell {
     @IBOutlet weak var nowPlayingIndicator: UIImageView!
     @IBOutlet weak var profileImageView: UIImageView!
     
+    var artworkUrl: URL?
+    var profileImageUrl: URL?
+    
     override func awakeFromNib() {
         super.awakeFromNib()
         

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -287,32 +287,46 @@ extension RequestsViewController: UITableViewDataSource {
             song = ConnectionController.shared.receivedSongs[indexPath.row]
         }
         
-        let indexOfNowPlayingItem = isDJ
-                                  ? PlayerQueue.shared.mpAppController.indexOfNowPlayingItem
-                                  : RequestsViewController.self.indexOfNowPlayingItemOnListener
         cell.title.text    = song.title
         cell.artist.text   = song.artist
-
-        cell.nowPlayingIndicator.isHidden = indexOfNowPlayingItem != indexPath.row
+        if cell.artworkUrl != song.artworkUrl {
+            cell.artwork.image = nil
+        }
+        cell.artworkUrl    = song.artworkUrl
         
         DispatchQueue.global().async {
             let image = CachedImage.fetch(url: song.artworkUrl)
             DispatchQueue.main.async {
-                cell.artwork.image = image  // 画像の取得に失敗していたらnilが入ることに注意
-                cell.artwork.setNeedsLayout()
+                if let cell = self.tableView.cellForRow(at: indexPath) as? RequestsMusicTableViewCell {
+                    cell.artwork.image = image  // 画像の取得に失敗していたらnilが入ることに注意
+                    cell.artwork.setNeedsLayout()
+                }
             }
         }
         if let profileImageUrl = song.profileImageUrl {
+            if cell.profileImageUrl != profileImageUrl {
+                cell.artwork.image = nil
+            }
+            cell.profileImageUrl = profileImageUrl
             DispatchQueue.global().async {
                 let image = CachedImage.fetch(url: profileImageUrl)
                 DispatchQueue.main.async {
-                    cell.profileImageView.image = image
-                    cell.profileImageView.setNeedsLayout()
+                    if let cell = self.tableView.cellForRow(at: indexPath) as? RequestsMusicTableViewCell {
+                        cell.profileImageView.image = image
+                        cell.profileImageView.setNeedsLayout()
+                    }
                 }
             }
         } else {
             cell.profileImageView.image = nil
         }
+
+        let indexOfNowPlayingItem = isDJ
+                                  ? PlayerQueue.shared.mpAppController.indexOfNowPlayingItem
+                                  : RequestsViewController.self.indexOfNowPlayingItemOnListener
+
+        cell.nowPlayingIndicator.isHidden = indexOfNowPlayingItem != indexPath.row
+
         if (indexPath.row < indexOfNowPlayingItem) {
             cell.title.alpha    = 0.3
             cell.artist.alpha   = 0.3

--- a/DJYusaku/SearchMusicTableViewCell.swift
+++ b/DJYusaku/SearchMusicTableViewCell.swift
@@ -14,6 +14,8 @@ class SearchMusicTableViewCell: UITableViewCell {
     @IBOutlet weak var artist: UILabel!
     @IBOutlet weak var artwork: UIImageView!
     
+    var artworkUrl: URL?
+    
     override func awakeFromNib() {
         super.awakeFromNib()
         

--- a/DJYusaku/SearchViewController.swift
+++ b/DJYusaku/SearchViewController.swift
@@ -95,14 +95,19 @@ extension SearchViewController: UITableViewDataSource {
         let item = results[indexPath.row]
         cell.title.text       = item.title
         cell.artist.text      = item.artist
-        cell.artwork.image    = defaultArtwork
+        if cell.artworkUrl != item.artworkUrl {
+            cell.artwork.image = defaultArtwork
+        }
+        cell.artworkUrl       = item.artworkUrl
         
         self.imageFetchWorkItem[indexPath.row]?.cancel()
         self.imageFetchWorkItem[indexPath.row] = DispatchWorkItem {
             let image = CachedImage.fetch(url: item.artworkUrl)
             DispatchQueue.main.async {
-                cell.artwork.image = image  // 画像の取得に失敗していたらnilが入ることに注意
-                cell.artwork.setNeedsLayout()
+                if let cell = self.tableView.cellForRow(at: indexPath) as? SearchMusicTableViewCell {
+                    cell.artwork.image = image  // 画像の取得に失敗していたらnilが入ることに注意
+                    cell.artwork.setNeedsLayout()
+                }
             }
         }
         imageFetchQueue.async(execute: self.imageFetchWorkItem[indexPath.row]!)


### PR DESCRIPTION
TableViewCellはインスタンスが使い回されるため、意図しない画像（そのセルにその画像が入るのはおかしい状態）が入ることがある。
現在の実装では**待てば**いつか正しい画像が入るという実装になっているが、やはり意図しない画像が入るのは気持ち悪いので直す。
以下の2つの問題を解決した。
1. すでに画像がfetch済みのセルのインスタンスを使いまわすことで意図しない画像が最初入っている問題
2. 画像のダウンロード完了前にスクロールすることで、意図しないセルにダウンロードした画像が入ってしまう問題（ダウンロード完了後に入れるはずだったセルが見えなくなっていたとき発生する）

1については単に最初にnilを代入すれば解決するが、それではtableView.reloadDataするたびにちらついてしまう。
ちらつかないようにするために、cellがURLを保持し、それと比較して一致しなかったらnilを代入するようにした。

#### 参考
https://stackoverflow.com/questions/16663618/async-image-loading-from-url-inside-a-uitableview-cell-image-changes-to-wrong