### PR TITLE
[WIP]省電力モード画面に現在再生中の楽曲情報を表示

### DIFF
--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -626,14 +626,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 12;
-				DEVELOPMENT_TEAM = 29WP3DF4XR;
+				DEVELOPMENT_TEAM = J87XZSWPMZ;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.4;
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.amylase;
 				PRODUCT_NAME = Juke;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -647,14 +647,14 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 12;
-				DEVELOPMENT_TEAM = 29WP3DF4XR;
+				DEVELOPMENT_TEAM = J87XZSWPMZ;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.4;
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.amylase;
 				PRODUCT_NAME = Juke;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -856,37 +856,59 @@
                                     <constraint firstAttribute="trailing" secondItem="whP-AR-UDb" secondAttribute="trailing" id="bUV-rr-7iy"/>
                                 </constraints>
                             </view>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mcg-F5-Ag6" userLabel="Nowplaying View">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mcg-F5-Ag6" userLabel="Nowplaying View">
                                 <rect key="frame" x="40" y="271" width="295" height="280"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="T0H-AM-waI" userLabel="Artwork">
-                                        <rect key="frame" x="123" y="42" width="48" height="48"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="T0H-AM-waI" userLabel="Artwork">
+                                        <rect key="frame" x="123.66666666666666" y="56" width="48" height="48"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="48" id="AIR-41-1Nm"/>
+                                            <constraint firstAttribute="height" constant="48" id="p0B-Hi-zJ2"/>
+                                        </constraints>
                                     </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="70q-sl-adH" userLabel="Artist">
-                                        <rect key="frame" x="35" y="170" width="224" height="28"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="70q-sl-adH" userLabel="Artist">
+                                        <rect key="frame" x="0.0" y="124" width="295" height="28"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="28" id="kIb-0h-uL8"/>
+                                        </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="28"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iZH-nQ-dgv" userLabel="Title">
-                                        <rect key="frame" x="35" y="126" width="224" height="28"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iZH-nQ-dgv" userLabel="Title">
+                                        <rect key="frame" x="0.0" y="182" width="295" height="28"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="28" id="DXN-gj-diG"/>
+                                        </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="28"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
+                                <color key="backgroundColor" systemColor="systemPurpleColor" red="0.68627450980000004" green="0.32156862749999998" blue="0.87058823529999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstItem="70q-sl-adH" firstAttribute="top" secondItem="T0H-AM-waI" secondAttribute="bottom" constant="20" id="1P8-Ob-IkL"/>
+                                    <constraint firstAttribute="trailing" secondItem="iZH-nQ-dgv" secondAttribute="trailing" id="3Bg-b4-JXW"/>
+                                    <constraint firstItem="T0H-AM-waI" firstAttribute="centerX" secondItem="mcg-F5-Ag6" secondAttribute="centerX" id="Gu8-EF-ja2"/>
+                                    <constraint firstItem="T0H-AM-waI" firstAttribute="centerY" secondItem="mcg-F5-Ag6" secondAttribute="centerY" constant="-60" id="Mnx-Qc-U5H"/>
+                                    <constraint firstItem="70q-sl-adH" firstAttribute="leading" secondItem="mcg-F5-Ag6" secondAttribute="leading" id="QJL-GT-22S"/>
+                                    <constraint firstAttribute="height" constant="280" id="QjX-t9-HD8"/>
+                                    <constraint firstItem="iZH-nQ-dgv" firstAttribute="leading" secondItem="mcg-F5-Ag6" secondAttribute="leading" id="q9E-GR-ina"/>
+                                    <constraint firstAttribute="trailing" secondItem="70q-sl-adH" secondAttribute="trailing" id="seh-Bq-0Dw"/>
+                                    <constraint firstItem="iZH-nQ-dgv" firstAttribute="top" secondItem="70q-sl-adH" secondAttribute="bottom" constant="30" id="xN8-DE-XOA"/>
+                                </constraints>
                             </view>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="Fx4-pT-4uu" firstAttribute="leading" secondItem="ioa-To-8ez" secondAttribute="leading" constant="40" id="5gJ-Kk-CEi"/>
                             <constraint firstItem="Fx4-pT-4uu" firstAttribute="centerX" secondItem="ioa-To-8ez" secondAttribute="centerX" id="90T-2R-Y0V"/>
+                            <constraint firstItem="mcg-F5-Ag6" firstAttribute="centerY" secondItem="ioa-To-8ez" secondAttribute="centerY" id="CMR-5t-6mG"/>
                             <constraint firstItem="Fx4-pT-4uu" firstAttribute="centerY" secondItem="ioa-To-8ez" secondAttribute="centerY" id="Fd2-Lo-jI7"/>
+                            <constraint firstItem="ioa-To-8ez" firstAttribute="trailing" secondItem="mcg-F5-Ag6" secondAttribute="trailing" constant="40" id="LYy-HP-DFg"/>
                             <constraint firstItem="ioa-To-8ez" firstAttribute="trailing" secondItem="Fx4-pT-4uu" secondAttribute="trailing" constant="40" id="OqE-Lp-M50"/>
+                            <constraint firstItem="mcg-F5-Ag6" firstAttribute="leading" secondItem="ioa-To-8ez" secondAttribute="leading" constant="40" id="QWO-u2-Z7B"/>
+                            <constraint firstItem="mcg-F5-Ag6" firstAttribute="centerX" secondItem="ioa-To-8ez" secondAttribute="centerX" id="gBy-JU-AQy"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="ioa-To-8ez"/>
                     </view>

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -859,24 +859,8 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mcg-F5-Ag6" userLabel="Nowplaying View">
                                 <rect key="frame" x="40" y="313" width="334" height="280"/>
                                 <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="T0H-AM-waI" userLabel="Artwork">
-                                        <rect key="frame" x="143" y="56" width="48" height="48"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="48" id="AIR-41-1Nm"/>
-                                            <constraint firstAttribute="height" constant="48" id="p0B-Hi-zJ2"/>
-                                        </constraints>
-                                    </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="70q-sl-adH" userLabel="Artist">
-                                        <rect key="frame" x="0.0" y="124" width="334" height="28"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="28" id="kIb-0h-uL8"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="28"/>
-                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iZH-nQ-dgv" userLabel="Title">
-                                        <rect key="frame" x="0.0" y="182" width="334" height="28"/>
+                                        <rect key="frame" x="0.0" y="124" width="334" height="28"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="28" id="DXN-gj-diG"/>
                                         </constraints>
@@ -884,17 +868,33 @@
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="70q-sl-adH" userLabel="Artist">
+                                        <rect key="frame" x="0.0" y="174" width="334" height="28"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="28" id="kIb-0h-uL8"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="28"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="CXz-ea-F1e" userLabel="Artwork">
+                                        <rect key="frame" x="143" y="66" width="48" height="48"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="48" id="E1m-on-PPc"/>
+                                            <constraint firstAttribute="width" constant="48" id="MTA-Qe-UeF"/>
+                                        </constraints>
+                                    </imageView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="70q-sl-adH" firstAttribute="top" secondItem="T0H-AM-waI" secondAttribute="bottom" constant="20" id="1P8-Ob-IkL"/>
                                     <constraint firstAttribute="trailing" secondItem="iZH-nQ-dgv" secondAttribute="trailing" id="3Bg-b4-JXW"/>
-                                    <constraint firstItem="T0H-AM-waI" firstAttribute="centerX" secondItem="mcg-F5-Ag6" secondAttribute="centerX" id="Gu8-EF-ja2"/>
-                                    <constraint firstItem="T0H-AM-waI" firstAttribute="centerY" secondItem="mcg-F5-Ag6" secondAttribute="centerY" constant="-60" id="Mnx-Qc-U5H"/>
+                                    <constraint firstItem="iZH-nQ-dgv" firstAttribute="top" secondItem="CXz-ea-F1e" secondAttribute="bottom" constant="10" id="9Sg-il-6IZ"/>
                                     <constraint firstItem="70q-sl-adH" firstAttribute="leading" secondItem="mcg-F5-Ag6" secondAttribute="leading" id="QJL-GT-22S"/>
                                     <constraint firstAttribute="height" constant="280" id="QjX-t9-HD8"/>
+                                    <constraint firstItem="70q-sl-adH" firstAttribute="top" secondItem="iZH-nQ-dgv" secondAttribute="bottom" constant="22" id="Vts-17-gIj"/>
+                                    <constraint firstItem="CXz-ea-F1e" firstAttribute="centerY" secondItem="mcg-F5-Ag6" secondAttribute="centerY" constant="-50" id="d3W-lB-hSg"/>
                                     <constraint firstItem="iZH-nQ-dgv" firstAttribute="leading" secondItem="mcg-F5-Ag6" secondAttribute="leading" id="q9E-GR-ina"/>
                                     <constraint firstAttribute="trailing" secondItem="70q-sl-adH" secondAttribute="trailing" id="seh-Bq-0Dw"/>
-                                    <constraint firstItem="iZH-nQ-dgv" firstAttribute="top" secondItem="70q-sl-adH" secondAttribute="bottom" constant="30" id="xN8-DE-XOA"/>
+                                    <constraint firstItem="CXz-ea-F1e" firstAttribute="centerX" secondItem="mcg-F5-Ag6" secondAttribute="centerX" id="wNT-o2-3e7"/>
                                 </constraints>
                             </view>
                         </subviews>
@@ -913,10 +913,10 @@
                     </view>
                     <connections>
                         <outlet property="noteView" destination="Fx4-pT-4uu" id="IBf-SR-nXz"/>
-                        <outlet property="nowplayingArtist" destination="70q-sl-adH" id="PU8-xf-J93"/>
-                        <outlet property="nowplayingArtwork" destination="T0H-AM-waI" id="m1G-xi-XLx"/>
-                        <outlet property="nowplayingTitle" destination="iZH-nQ-dgv" id="YKo-4T-uBe"/>
-                        <outlet property="nowplayingView" destination="mcg-F5-Ag6" id="nAM-El-GOn"/>
+                        <outlet property="nowPlayingArtist" destination="70q-sl-adH" id="Zcr-gm-LpN"/>
+                        <outlet property="nowPlayingArtwork" destination="CXz-ea-F1e" id="Uno-fl-85Z"/>
+                        <outlet property="nowPlayingTitle" destination="iZH-nQ-dgv" id="k3X-eM-fRl"/>
+                        <outlet property="nowPlayingView" destination="mcg-F5-Ag6" id="xvI-Yj-uaD"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="IbK-vi-r2D" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -860,7 +860,7 @@
                                 <rect key="frame" x="40" y="313" width="334" height="280"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iZH-nQ-dgv" userLabel="Title">
-                                        <rect key="frame" x="0.0" y="124" width="334" height="28"/>
+                                        <rect key="frame" x="0.0" y="110" width="334" height="28"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="28" id="DXN-gj-diG"/>
                                         </constraints>
@@ -869,7 +869,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="70q-sl-adH" userLabel="Artist">
-                                        <rect key="frame" x="0.0" y="174" width="334" height="28"/>
+                                        <rect key="frame" x="0.0" y="154" width="334" height="28"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="28" id="kIb-0h-uL8"/>
                                         </constraints>
@@ -878,20 +878,32 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="CXz-ea-F1e" userLabel="Artwork">
-                                        <rect key="frame" x="143" y="66" width="48" height="48"/>
+                                        <rect key="frame" x="143" y="46" width="48" height="48"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="48" id="E1m-on-PPc"/>
                                             <constraint firstAttribute="width" constant="48" id="MTA-Qe-UeF"/>
                                         </constraints>
                                     </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="To exit battery saver mode, double-tap the screen." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7II-4V-DS7">
+                                        <rect key="frame" x="0.0" y="190" width="334" height="64"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="64" id="qHq-ee-zzW"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                 </subviews>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="iZH-nQ-dgv" secondAttribute="trailing" id="3Bg-b4-JXW"/>
-                                    <constraint firstItem="iZH-nQ-dgv" firstAttribute="top" secondItem="CXz-ea-F1e" secondAttribute="bottom" constant="10" id="9Sg-il-6IZ"/>
+                                    <constraint firstItem="iZH-nQ-dgv" firstAttribute="top" secondItem="CXz-ea-F1e" secondAttribute="bottom" constant="16" id="9Sg-il-6IZ"/>
+                                    <constraint firstAttribute="trailing" secondItem="7II-4V-DS7" secondAttribute="trailing" id="IJV-6S-gR8"/>
+                                    <constraint firstItem="7II-4V-DS7" firstAttribute="top" secondItem="70q-sl-adH" secondAttribute="bottom" constant="8" id="NR9-Ww-Rws"/>
                                     <constraint firstItem="70q-sl-adH" firstAttribute="leading" secondItem="mcg-F5-Ag6" secondAttribute="leading" id="QJL-GT-22S"/>
                                     <constraint firstAttribute="height" constant="280" id="QjX-t9-HD8"/>
-                                    <constraint firstItem="70q-sl-adH" firstAttribute="top" secondItem="iZH-nQ-dgv" secondAttribute="bottom" constant="22" id="Vts-17-gIj"/>
-                                    <constraint firstItem="CXz-ea-F1e" firstAttribute="centerY" secondItem="mcg-F5-Ag6" secondAttribute="centerY" constant="-50" id="d3W-lB-hSg"/>
+                                    <constraint firstItem="70q-sl-adH" firstAttribute="top" secondItem="iZH-nQ-dgv" secondAttribute="bottom" constant="16" id="Vts-17-gIj"/>
+                                    <constraint firstItem="CXz-ea-F1e" firstAttribute="centerY" secondItem="mcg-F5-Ag6" secondAttribute="centerY" constant="-70" id="d3W-lB-hSg"/>
+                                    <constraint firstItem="7II-4V-DS7" firstAttribute="leading" secondItem="mcg-F5-Ag6" secondAttribute="leading" id="hr3-9J-4Z8"/>
                                     <constraint firstItem="iZH-nQ-dgv" firstAttribute="leading" secondItem="mcg-F5-Ag6" secondAttribute="leading" id="q9E-GR-ina"/>
                                     <constraint firstAttribute="trailing" secondItem="70q-sl-adH" secondAttribute="trailing" id="seh-Bq-0Dw"/>
                                     <constraint firstItem="CXz-ea-F1e" firstAttribute="centerX" secondItem="mcg-F5-Ag6" secondAttribute="centerX" id="wNT-o2-3e7"/>
@@ -921,7 +933,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="IbK-vi-r2D" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2623.1999999999998" y="-583.74384236453204"/>
+            <point key="canvasLocation" x="2623.1884057971015" y="-583.92857142857144"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="yl2-sM-qoP">

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
-    <device id="retina5_9" orientation="portrait" appearance="light"/>
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
@@ -13,22 +13,22 @@
             <objects>
                 <viewController id="9pv-A4-QxB" customClass="RequestsViewController" customModule="Juke" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tsR-hK-woN">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="641"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="725"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="64" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="2ub-dF-W8m">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="641"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="725"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="playback" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="RequestsMusicTableViewCell" id="T5J-aV-tbm" customClass="RequestsMusicTableViewCell" customModule="Juke" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="64"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="64"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="T5J-aV-tbm" id="Bkg-rZ-UB5">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="64"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="4BI-ax-603">
-                                                    <rect key="frame" x="15" y="8" width="48" height="48"/>
+                                                    <rect key="frame" x="20" y="8" width="48" height="48"/>
                                                     <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="48" id="VnY-OX-Jrk"/>
@@ -37,19 +37,19 @@
                                                     <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="small"/>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Music Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yug-k8-ppk">
-                                                    <rect key="frame" x="83" y="12" width="252" height="20"/>
+                                                    <rect key="frame" x="88" y="12" width="286" height="20"/>
                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Artist" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hw4-hv-Z0J">
-                                                    <rect key="frame" x="83" y="32" width="252" height="20"/>
+                                                    <rect key="frame" x="88" y="32" width="286" height="20"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView hidden="YES" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="circle.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="eYn-Ib-chP">
-                                                    <rect key="frame" x="343" y="25" width="16" height="14.666666666666671"/>
+                                                    <rect key="frame" x="382" y="24.5" width="16" height="15"/>
                                                     <color key="tintColor" name="YusakuPinkColor"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="16" id="BDz-LO-di8"/>
@@ -57,7 +57,7 @@
                                                     </constraints>
                                                 </imageView>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="lBC-32-BW1">
-                                                    <rect key="frame" x="47" y="27" width="32" height="32"/>
+                                                    <rect key="frame" x="52" y="27" width="32" height="32"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="32" id="L6Z-tK-GUE"/>
                                                         <constraint firstAttribute="height" constant="32" id="sG7-x8-vWG"/>
@@ -91,10 +91,10 @@
                                 </prototypes>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KuE-ce-LIi" userLabel="NoRequestsView">
-                                <rect key="frame" x="67.666666666666686" y="170.66666666666669" width="240" height="300"/>
+                                <rect key="frame" x="87" y="212.5" width="240" height="300"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="music.bubble.pink" translatesAutoresizingMaskIntoConstraints="NO" id="DB5-VE-YZb">
-                                        <rect key="frame" x="95.999999999999986" y="106" width="48.000000000000014" height="48"/>
+                                        <rect key="frame" x="96" y="106" width="48" height="48"/>
                                         <color key="tintColor" name="YusakuPinkColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="48" id="5WZ-ss-MXU"/>
@@ -102,7 +102,7 @@
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Requested songs  will be shown here" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g6q-4j-3bI" userLabel="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod">
-                                        <rect key="frame" x="0.0" y="162" width="240" height="33.666666666666657"/>
+                                        <rect key="frame" x="0.0" y="162" width="240" height="33.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -119,7 +119,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9aA-O6-Z64" userLabel="PlayerControllerVIew">
-                                <rect key="frame" x="57.666666666666657" y="529" width="260" height="80"/>
+                                <rect key="frame" x="77" y="613" width="260" height="80"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sYe-8j-hTb">
                                         <rect key="frame" x="178" y="8" width="64" height="64"/>
@@ -138,7 +138,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VTg-nf-1br">
-                                        <rect key="frame" x="18.000000000000007" y="8" width="63.999999999999993" height="64"/>
+                                        <rect key="frame" x="18" y="8" width="64" height="64"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="64" id="1wF-9l-KOo"/>
                                             <constraint firstAttribute="height" constant="64" id="o6M-9a-6gX"/>
@@ -222,17 +222,17 @@
             <objects>
                 <viewController title="Welcome" id="ypK-t8-Qz5" customClass="WelcomeViewController" customModule="Juke" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="zoG-Zx-5x5">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="702"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="786"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" alpha="0.10000000000000001" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="WelcomeJuke" translatesAutoresizingMaskIntoConstraints="NO" id="hGA-PT-Q4g">
-                                <rect key="frame" x="56.333333333333343" y="0.0" width="412.33333333333326" height="412.66666666666669"/>
+                                <rect key="frame" x="62" y="0.0" width="455.5" height="455.5"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="hGA-PT-Q4g" secondAttribute="height" multiplier="1:1" id="fr8-Lm-WSs"/>
                                 </constraints>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="90a-jE-PNH">
-                                <rect key="frame" x="75" y="379" width="225" height="44"/>
+                                <rect key="frame" x="83" y="421" width="248" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="oaD-oG-UH6"/>
                                 </constraints>
@@ -246,7 +246,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RGD-qI-6Bt">
-                                <rect key="frame" x="75" y="461" width="225" height="44"/>
+                                <rect key="frame" x="83" y="503" width="248" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="4xT-wQ-5Cn"/>
                                 </constraints>
@@ -260,25 +260,25 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="requires Apple Music membership" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QLv-BI-r7q">
-                                <rect key="frame" x="0.0" y="427" width="375" height="15"/>
+                                <rect key="frame" x="0.0" y="469" width="414" height="15"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Logo" translatesAutoresizingMaskIntoConstraints="NO" id="LZr-FI-GlJ">
-                                <rect key="frame" x="87.666666666666686" y="231" width="200" height="100"/>
+                                <rect key="frame" x="107" y="223" width="200" height="200"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="200" id="Zh3-0L-qL5"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="© 2020 Yusaku" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S0h-WO-K7i">
-                                <rect key="frame" x="87.666666666666686" y="335" width="200" height="14.333333333333314"/>
+                                <rect key="frame" x="107" y="427" width="200" height="14.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FHg-xT-x4r">
-                                <rect key="frame" x="16" y="638" width="48" height="48"/>
+                                <rect key="frame" x="16" y="722" width="48" height="48"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="48" id="UL1-9W-WBM"/>
                                     <constraint firstAttribute="width" constant="48" id="eta-Bv-fOv"/>
@@ -341,11 +341,11 @@
             <objects>
                 <viewController storyboardIdentifier="TutorialView" id="BW4-gN-1JX" customClass="TutorialViewController" customModule="Juke" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="U3l-fo-nA0">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="758"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="4" translatesAutoresizingMaskIntoConstraints="NO" id="kyL-vN-6F5">
-                                <rect key="frame" x="160" y="687" width="55" height="37"/>
+                                <rect key="frame" x="179.5" y="771" width="55" height="37"/>
                             </pageControl>
                         </subviews>
                         <color key="backgroundColor" name="YusakuPinkColor"/>
@@ -369,11 +369,11 @@
             <objects>
                 <viewController storyboardIdentifier="TutorialFirstViewController" id="sZ9-Wy-X5c" customClass="TutorialFirstViewController" customModule="Juke" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Om6-Fb-Z0I">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Juke allows you to make and play playlists by &quot;requesting&quot; songs to the other who subscribes to Apple Music." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bSx-NQ-Bh4">
-                                <rect key="frame" x="47" y="473" width="281" height="50.333333333333371"/>
+                                <rect key="frame" x="52" y="565" width="310.5" height="50.5"/>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -382,35 +382,35 @@
                                 </variation>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="LogoWhite" translatesAutoresizingMaskIntoConstraints="NO" id="Xcd-pM-qNx">
-                                <rect key="frame" x="91.666666666666686" y="361" width="192" height="100"/>
+                                <rect key="frame" x="111" y="353" width="192" height="200"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="192" id="oul-qf-lS9"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome to" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xjw-4N-jZQ">
-                                <rect key="frame" x="91.666666666666686" y="334.66666666666669" width="192" height="38.333333333333314"/>
+                                <rect key="frame" x="111" y="326.5" width="192" height="38.5"/>
                                 <fontDescription key="fontDescription" type="system" weight="thin" pointSize="32"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="BorderedAppIcon" translatesAutoresizingMaskIntoConstraints="NO" id="2EG-oP-0Cn">
-                                <rect key="frame" x="130.66666666666666" y="212.66666666666663" width="114" height="114"/>
+                                <rect key="frame" x="150" y="204.5" width="114" height="114"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="114" id="jcK-ri-F86"/>
                                     <constraint firstAttribute="width" constant="114" id="omu-p7-cfi"/>
                                 </constraints>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Mnt-FB-mXs">
-                                <rect key="frame" x="97.666666666666686" y="730" width="180" height="32"/>
+                                <rect key="frame" x="117" y="814" width="180" height="32"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Swipe left to next" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8rH-1d-ew6">
-                                        <rect key="frame" x="0.0" y="4.6666666666666288" width="158" height="23"/>
+                                        <rect key="frame" x="0.0" y="4.5" width="158" height="23"/>
                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="19"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="UhT-D7-9TU">
-                                        <rect key="frame" x="158" y="7.3333333333332931" width="22" height="17.666666666666671"/>
+                                        <rect key="frame" x="158" y="7" width="22" height="17.5"/>
                                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="22" id="WWX-MD-D9r"/>
@@ -456,18 +456,18 @@
             <objects>
                 <viewController storyboardIdentifier="TutorialSecondViewController" id="ugP-90-YnU" customClass="TutorialSecondViewController" customModule="Juke" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5hl-hA-W7U">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="music.bubble" translatesAutoresizingMaskIntoConstraints="NO" id="xlq-cL-zzL">
-                                <rect key="frame" x="40" y="646" width="24" height="24"/>
+                                <rect key="frame" x="40" y="730" width="24" height="24"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="24" id="2cy-lA-JtP"/>
                                     <constraint firstAttribute="width" constant="24" id="Qm3-bO-gil"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Request." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="arv-7n-e5O">
-                                <rect key="frame" x="76" y="646" width="259" height="24"/>
+                                <rect key="frame" x="76" y="730" width="298" height="24"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -476,13 +476,13 @@
                                 </variation>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="TutorialRequest" translatesAutoresizingMaskIntoConstraints="NO" id="Ctj-rB-wwY">
-                                <rect key="frame" x="40" y="68" width="295" height="554"/>
+                                <rect key="frame" x="40" y="68" width="334" height="638"/>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vQ9-5M-JKu">
-                                <rect key="frame" x="40" y="678" width="295" height="68"/>
+                                <rect key="frame" x="40" y="762" width="334" height="68"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JFi-qC-Yoa">
-                                        <rect key="frame" x="0.0" y="0.0" width="295" height="68"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="334" height="68"/>
                                         <string key="text">After you create a session (or join a session), search Apple Music for the song you want to play and "request" it to the session master.</string>
                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -538,22 +538,22 @@
             <objects>
                 <viewController id="2ZU-rh-NCc" customClass="ListenerConnectionViewController" customModule="Juke" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="TEh-b3-bIb">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="702"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="786"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="64" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="BXT-Va-ZlK">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="702"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="786"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="ListenerConnectableDJsTableViewCell" id="Hmp-1P-PDK" customClass="ListenerConnectableDJsTableViewCell" customModule="Juke" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="64"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="64"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Hmp-1P-PDK" id="mhw-qc-RfJ">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="64"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KK9-dh-Qaa">
-                                                    <rect key="frame" x="72" y="16" width="219" height="32"/>
+                                                    <rect key="frame" x="72" y="16" width="258" height="32"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="32" id="7nV-4J-FpJ"/>
                                                     </constraints>
@@ -569,7 +569,7 @@
                                                     </constraints>
                                                 </imageView>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4Ew-Lp-Gqh">
-                                                    <rect key="frame" x="299" y="16" width="64" height="32"/>
+                                                    <rect key="frame" x="338" y="16" width="64" height="32"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0/8" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YiX-nO-KLp">
                                                             <rect key="frame" x="0.0" y="0.0" width="64" height="32"/>
@@ -608,10 +608,10 @@
                                 </prototypes>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="37a-eQ-Dej" userLabel="NoConnectableDJsView">
-                                <rect key="frame" x="67.666666666666686" y="121" width="240" height="300"/>
+                                <rect key="frame" x="87" y="163" width="240" height="300"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="JukeNoSearchResults" translatesAutoresizingMaskIntoConstraints="NO" id="jKe-FC-egM">
-                                        <rect key="frame" x="71.999999999999986" y="82" width="96.000000000000014" height="96"/>
+                                        <rect key="frame" x="72" y="82" width="96" height="96"/>
                                         <color key="tintColor" name="YusakuPinkColor"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="96" id="Y4o-4Q-mOd"/>
@@ -662,22 +662,22 @@
             <objects>
                 <viewController id="8rJ-Kc-sve" customClass="SearchViewController" customModule="Juke" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="QS5-Rx-YEW">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="724"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="64" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="wCp-R2-0r7">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="690"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="774"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SearchMusicTableViewCell" id="Uxy-eD-cUw" customClass="SearchMusicTableViewCell" customModule="Juke" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="64"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="64"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Uxy-eD-cUw" id="jsM-e1-0mc">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="64"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="TemporarySingleColored" translatesAutoresizingMaskIntoConstraints="NO" id="rYB-jY-hDQ">
-                                                    <rect key="frame" x="15" y="8" width="48" height="48"/>
+                                                    <rect key="frame" x="20" y="8" width="48" height="48"/>
                                                     <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="48" id="Pry-Xv-Br7"/>
@@ -686,13 +686,13 @@
                                                     <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="small"/>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Music Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DxG-x9-Q3o">
-                                                    <rect key="frame" x="71" y="12" width="288" height="20"/>
+                                                    <rect key="frame" x="76" y="12" width="322" height="20"/>
                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Artist" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UVM-Kb-uf9">
-                                                    <rect key="frame" x="71" y="31.666666666666671" width="288" height="21"/>
+                                                    <rect key="frame" x="76" y="31.5" width="322" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
@@ -719,17 +719,17 @@
                                 </prototypes>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FTn-HS-gCz" userLabel="NoSearchWordsView">
-                                <rect key="frame" x="67.666666666666686" y="0.0" width="240" height="300"/>
+                                <rect key="frame" x="87" y="0.0" width="240" height="300"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" alpha="0.75" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="SearchBarArrow" translatesAutoresizingMaskIntoConstraints="NO" id="kW2-O7-92P">
-                                        <rect key="frame" x="88.999999999999986" y="8" width="30" height="89"/>
+                                        <rect key="frame" x="89" y="8" width="30" height="89"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="89" id="JEb-fN-CTK"/>
                                             <constraint firstAttribute="width" constant="30" id="uIH-MC-LhG"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="You can search for songs on Apple Music by song name, artist name, lyrics, etc. and request them." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XgZ-Sg-IAg">
-                                        <rect key="frame" x="0.0" y="101" width="240" height="50.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="101" width="240" height="50.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -744,10 +744,10 @@
                                 </constraints>
                             </view>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ez6-o0-DGd" userLabel="NoSearchResultsView">
-                                <rect key="frame" x="67.666666666666686" y="95" width="240" height="300"/>
+                                <rect key="frame" x="87" y="137" width="240" height="300"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="JukeNoSearchResults" translatesAutoresizingMaskIntoConstraints="NO" id="PSU-ER-fUe">
-                                        <rect key="frame" x="71.999999999999986" y="82" width="96.000000000000014" height="96"/>
+                                        <rect key="frame" x="72" y="82" width="96" height="96"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="96" id="a08-hg-iOn"/>
                                             <constraint firstAttribute="width" constant="96" id="tly-jd-xKz"/>
@@ -808,7 +808,7 @@
             <objects>
                 <viewController id="4uZ-Wj-ld5" customClass="DummyViewController" customModule="Juke" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="lsb-Hs-IUt">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="729"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="k9y-S4-zPG"/>
@@ -824,21 +824,21 @@
             <objects>
                 <viewController storyboardIdentifier="BatterySaverView" id="oZn-cn-RSW" customClass="BatterySaverViewController" customModule="Juke" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="JaV-wB-E59">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fx4-pT-4uu">
-                                <rect key="frame" x="40" y="271" width="295" height="280"/>
+                                <rect key="frame" x="40" y="313" width="334" height="280"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="JukeSleeping" translatesAutoresizingMaskIntoConstraints="NO" id="2gp-S6-Snf">
-                                        <rect key="frame" x="83.666666666666686" y="36" width="128" height="128"/>
+                                        <rect key="frame" x="103" y="36" width="128" height="128"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="128" id="TY2-Fc-Ul8"/>
                                             <constraint firstAttribute="width" constant="128" id="aXu-GC-fpb"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="To exit battery saver mode, double-tap the screen." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="whP-AR-UDb">
-                                        <rect key="frame" x="0.0" y="172" width="295" height="64"/>
+                                        <rect key="frame" x="0.0" y="172" width="334" height="64"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="64" id="D0M-n1-Wqq"/>
                                         </constraints>
@@ -857,17 +857,17 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mcg-F5-Ag6" userLabel="Nowplaying View">
-                                <rect key="frame" x="40" y="271" width="295" height="280"/>
+                                <rect key="frame" x="40" y="313" width="334" height="280"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="T0H-AM-waI" userLabel="Artwork">
-                                        <rect key="frame" x="123.66666666666666" y="56" width="48" height="48"/>
+                                        <rect key="frame" x="143" y="56" width="48" height="48"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="48" id="AIR-41-1Nm"/>
                                             <constraint firstAttribute="height" constant="48" id="p0B-Hi-zJ2"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="70q-sl-adH" userLabel="Artist">
-                                        <rect key="frame" x="0.0" y="124" width="295" height="28"/>
+                                        <rect key="frame" x="0.0" y="124" width="334" height="28"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="28" id="kIb-0h-uL8"/>
                                         </constraints>
@@ -876,7 +876,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iZH-nQ-dgv" userLabel="Title">
-                                        <rect key="frame" x="0.0" y="182" width="295" height="28"/>
+                                        <rect key="frame" x="0.0" y="182" width="334" height="28"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="28" id="DXN-gj-diG"/>
                                         </constraints>
@@ -885,7 +885,6 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemPurpleColor" red="0.68627450980000004" green="0.32156862749999998" blue="0.87058823529999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstItem="70q-sl-adH" firstAttribute="top" secondItem="T0H-AM-waI" secondAttribute="bottom" constant="20" id="1P8-Ob-IkL"/>
                                     <constraint firstAttribute="trailing" secondItem="iZH-nQ-dgv" secondAttribute="trailing" id="3Bg-b4-JXW"/>
@@ -914,6 +913,10 @@
                     </view>
                     <connections>
                         <outlet property="noteView" destination="Fx4-pT-4uu" id="IBf-SR-nXz"/>
+                        <outlet property="nowplayingArtist" destination="70q-sl-adH" id="PU8-xf-J93"/>
+                        <outlet property="nowplayingArtwork" destination="T0H-AM-waI" id="m1G-xi-XLx"/>
+                        <outlet property="nowplayingTitle" destination="iZH-nQ-dgv" id="YKo-4T-uBe"/>
+                        <outlet property="nowplayingView" destination="mcg-F5-Ag6" id="nAM-El-GOn"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="IbK-vi-r2D" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -948,7 +951,7 @@
                     <tabBarItem key="tabBarItem" title="Search" image="magnifyingglass" catalog="system" id="cPa-gy-q4n"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translucent="NO" id="t5Y-gP-1Ll">
-                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" name="YusakuPinkColor"/>
                     </navigationBar>
@@ -968,7 +971,7 @@
                     <tabBarItem key="tabBarItem" title="Requests" image="music.note.list" catalog="system" id="acW-dT-cKf"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translucent="NO" id="NXp-M8-OkR">
-                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <color key="barTintColor" name="YusakuPinkColor"/>
@@ -991,7 +994,7 @@
                 <navigationController storyboardIdentifier="WelcomeNavigation" automaticallyAdjustsScrollViewInsets="NO" id="dBJ-r9-osw" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translucent="NO" id="AAD-aP-xyu">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" name="YusakuPinkColor"/>
                         <color key="barTintColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
@@ -1010,18 +1013,18 @@
             <objects>
                 <viewController id="ODD-3q-aMv" customClass="MemberViewController" customModule="Juke" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="4UC-dV-YyJ">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="641"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="725"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="64" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="ljm-v3-8g9">
-                                <rect key="frame" x="0.0" y="254" width="375" height="387"/>
+                                <rect key="frame" x="0.0" y="254" width="414" height="471"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MemberTableViewCell" id="MsJ-dR-GdV" customClass="MemberTableViewCell" customModule="Juke" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="64"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="64"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="MsJ-dR-GdV" id="Oji-6z-nXc">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="64"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="fpU-yS-Emb" userLabel="PeerImage">
@@ -1032,7 +1035,7 @@
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WKd-f8-to8" userLabel="PeerName">
-                                                    <rect key="frame" x="72" y="21.666666666666671" width="224" height="21"/>
+                                                    <rect key="frame" x="72" y="21.5" width="263" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="21" id="jru-If-yFn"/>
                                                     </constraints>
@@ -1041,7 +1044,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2hQ-rE-pRE">
-                                                    <rect key="frame" x="304" y="18" width="56" height="28"/>
+                                                    <rect key="frame" x="343" y="18" width="56" height="28"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="You" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="smN-R0-RlJ">
                                                             <rect key="frame" x="0.0" y="0.0" width="56" height="28"/>
@@ -1089,10 +1092,10 @@
                                 </prototypes>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="x2S-SF-hBr" userLabel="NoListenersView">
-                                <rect key="frame" x="67.666666666666686" y="297.66666666666669" width="240" height="300.00000000000006"/>
+                                <rect key="frame" x="87" y="339.5" width="240" height="300"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No members" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Xn-Xd-sPA">
-                                        <rect key="frame" x="0.0" y="141.33333333333331" width="240" height="17"/>
+                                        <rect key="frame" x="0.0" y="141.5" width="240" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -1107,16 +1110,16 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yP3-9N-fvb" userLabel="DJName">
-                                <rect key="frame" x="40" y="146" width="295" height="33.666666666666657"/>
+                                <rect key="frame" x="40" y="146" width="334" height="33.5"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="28"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YwJ-0O-PKN">
-                                <rect key="frame" x="123.66666666666669" y="15" width="128" height="128"/>
+                                <rect key="frame" x="143" y="15" width="128" height="128"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="KmF-kX-f76" userLabel="PeerImage">
-                                        <rect key="frame" x="4.9999999999999858" y="5" width="118" height="118"/>
+                                        <rect key="frame" x="5" y="5" width="118" height="118"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="118" id="KBs-ay-c8n"/>
                                             <constraint firstAttribute="width" constant="118" id="iTt-bB-YCZ"/>
@@ -1132,13 +1135,13 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VV4-vI-kz8">
-                                <rect key="frame" x="0.0" y="222" width="375" height="24"/>
+                                <rect key="frame" x="0.0" y="222" width="414" height="24"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GLD-cn-Zs3">
-                                        <rect key="frame" x="0.0" y="0.0" width="287" height="24"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="326" height="24"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Session Members" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y0U-zI-jXg">
-                                                <rect key="frame" x="16" y="0.0" width="271" height="24"/>
+                                                <rect key="frame" x="16" y="0.0" width="310" height="24"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -1152,7 +1155,7 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="p1y-6w-PX7">
-                                        <rect key="frame" x="295" y="0.0" width="64" height="24"/>
+                                        <rect key="frame" x="334" y="0.0" width="64" height="24"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0/8" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RrF-7Q-5Pb">
                                                 <rect key="frame" x="0.0" y="0.0" width="64" height="24"/>
@@ -1183,7 +1186,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mi7-Rp-hSf">
-                                <rect key="frame" x="139.66666666666666" y="183.66666666666669" width="96" height="28"/>
+                                <rect key="frame" x="159" y="183.5" width="96" height="28"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Connecting" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Zn-fy-Vhb">
                                         <rect key="frame" x="0.0" y="0.0" width="96" height="28"/>
@@ -1264,27 +1267,27 @@
             <objects>
                 <tableViewController id="Xlt-eI-mT8" customClass="SettingsViewController" customModule="Juke" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="Z2X-f6-JOQ">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="641"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="725"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <sections>
                             <tableViewSection headerTitle="Your Profile" id="UGi-OW-Xv6">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="ElN-Ah-E0J" detailTextLabel="Bl7-8g-a7O" style="IBUITableViewCellStyleValue1" id="Sjw-Kf-fkj">
-                                        <rect key="frame" x="16" y="55.333332061767578" width="343" height="43.5"/>
+                                        <rect key="frame" x="20" y="55.5" width="374" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Sjw-Kf-fkj" id="wAb-Zn-ymh">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ElN-Ah-E0J">
-                                                    <rect key="frame" x="15" y="11.999999999999998" width="45" height="20.333333333333332"/>
+                                                    <rect key="frame" x="20" y="12" width="45" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Bl7-8g-a7O">
-                                                    <rect key="frame" x="284" y="11.999999999999998" width="44" height="20.333333333333332"/>
+                                                    <rect key="frame" x="310" y="12" width="44" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1301,21 +1304,21 @@
                             <tableViewSection headerTitle="Twitter" footerTitle="Logging in Twitter, you can use profile name and image of your Twitter account." id="JUc-MG-44H">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="1qy-wg-wl2" detailTextLabel="Y5i-Fz-AZG" style="IBUITableViewCellStyleValue1" id="jOM-o2-JH7">
-                                        <rect key="frame" x="16" y="162.16666412353516" width="343" height="43.5"/>
+                                        <rect key="frame" x="20" y="162.5" width="374" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="jOM-o2-JH7" id="6gR-az-BPu">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Account" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="1qy-wg-wl2">
-                                                    <rect key="frame" x="15.000000000000004" y="11.999999999999998" width="63.333333333333336" height="20.333333333333332"/>
+                                                    <rect key="frame" x="20" y="12" width="63.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="No account" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Y5i-Fz-AZG">
-                                                    <rect key="frame" x="239.66666666666671" y="11.999999999999998" width="88.333333333333329" height="20.333333333333332"/>
+                                                    <rect key="frame" x="265.5" y="12" width="88.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1325,14 +1328,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="ZUJ-JJ-l3v">
-                                        <rect key="frame" x="16" y="205.66666412353516" width="343" height="43.5"/>
+                                        <rect key="frame" x="20" y="206" width="374" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZUJ-JJ-l3v" id="NhU-Yo-yjx">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="u1w-l1-k2W">
-                                                    <rect key="frame" x="274" y="6.6666666666666679" width="49" height="31.000000000000004"/>
+                                                    <rect key="frame" x="305" y="6.5" width="49" height="31"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="47" id="A31-c2-7wx"/>
                                                         <constraint firstAttribute="height" constant="31" id="hMg-nQ-bAr"/>
@@ -1343,7 +1346,7 @@
                                                     </connections>
                                                 </switch>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Use Profile" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Nh-yi-nFf">
-                                                    <rect key="frame" x="15" y="11.666666666666664" width="313" height="21"/>
+                                                    <rect key="frame" x="15" y="11.5" width="344" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -1364,14 +1367,14 @@
                                 <string key="footerTitle">When system auto-lock is disabled, the screen will not auto-lock while this app is running. In battery saver mode, auto-lock will be disabled regardless of whether system auto-lock is enabled or not.</string>
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="VpO-rc-Owp">
-                                        <rect key="frame" x="16" y="340.49999618530273" width="343" height="43.5"/>
+                                        <rect key="frame" x="20" y="341" width="374" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="VpO-rc-Owp" id="HKR-sv-2ca">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fCY-sL-Iuc">
-                                                    <rect key="frame" x="274" y="6.6666666666666679" width="49" height="31.000000000000004"/>
+                                                    <rect key="frame" x="305" y="6.5" width="49" height="31"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="31" id="5d1-TP-IAz"/>
                                                         <constraint firstAttribute="width" constant="47" id="zhM-DZ-Tyx"/>
@@ -1382,7 +1385,7 @@
                                                     </connections>
                                                 </switch>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="System Auto-Lock" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="clx-m3-sFM">
-                                                    <rect key="frame" x="15" y="11.666666666666664" width="313" height="21"/>
+                                                    <rect key="frame" x="15" y="11.5" width="344" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -1402,14 +1405,14 @@
                             <tableViewSection id="c1Y-Le-C7u">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="IKi-es-3Ji" style="IBUITableViewCellStyleDefault" id="5oP-6Y-muh">
-                                        <rect key="frame" x="16" y="479.99999618530273" width="343" height="43.5"/>
+                                        <rect key="frame" x="20" y="480.5" width="374" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="5oP-6Y-muh" id="Q0o-gm-JIS">
-                                            <rect key="frame" x="0.0" y="0.0" width="317" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="343" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="About This App" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="IKi-es-3Ji">
-                                                    <rect key="frame" x="15" y="0.0" width="294" height="43.5"/>
+                                                    <rect key="frame" x="20" y="0.0" width="315" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1446,20 +1449,20 @@
             <objects>
                 <tableViewController id="SQY-EL-BYa" customClass="SettingsNameViewController" customModule="Juke" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="1k1-LV-HEC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="641"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="725"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <sections>
                             <tableViewSection footerTitle="Name will be shown to participants of the session. " id="vaN-CN-ABS">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="BPp-3x-EF7">
-                                        <rect key="frame" x="16" y="18" width="343" height="43.666667938232422"/>
+                                        <rect key="frame" x="20" y="18" width="374" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="BPp-3x-EF7" id="Mxm-1l-R8H">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="43.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Input your name here" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="SIY-O4-BJX">
-                                                    <rect key="frame" x="16" y="11.666666666666664" width="311" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="342" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <textInputTraits key="textInputTraits" returnKeyType="done"/>
                                                 </textField>
@@ -1493,27 +1496,27 @@
             <objects>
                 <tableViewController id="IZX-zN-OeS" customClass="SettingsAboutThisAppViewController" customModule="Juke" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="b84-DP-zow">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="641"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="725"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <sections>
                             <tableViewSection id="cVv-8L-fQD">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="GMN-mA-aEf" detailTextLabel="nqe-80-yWS" style="IBUITableViewCellStyleValue1" id="x2u-he-Ufk">
-                                        <rect key="frame" x="16" y="18" width="343" height="43.5"/>
+                                        <rect key="frame" x="20" y="18" width="374" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="x2u-he-Ufk" id="Bza-u1-aP8">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Version" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="GMN-mA-aEf">
-                                                    <rect key="frame" x="15" y="11.999999999999998" width="57" height="20.333333333333332"/>
+                                                    <rect key="frame" x="20" y="12" width="57" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Marketing Version" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="nqe-80-yWS">
-                                                    <rect key="frame" x="190" y="11.999999999999998" width="138" height="20.333333333333332"/>
+                                                    <rect key="frame" x="216" y="12" width="138" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1527,14 +1530,14 @@
                             <tableViewSection headerTitle="GitHub" id="znF-DA-Vz7">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="elk-Zp-L5e" style="IBUITableViewCellStyleDefault" id="6T6-R4-tdB">
-                                        <rect key="frame" x="16" y="117.5" width="343" height="43.5"/>
+                                        <rect key="frame" x="20" y="117.5" width="374" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="6T6-R4-tdB" id="ChU-Py-A2v">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="enpitut2019/dj-yusaku" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="elk-Zp-L5e">
-                                                    <rect key="frame" x="15" y="0.0" width="313" height="43.5"/>
+                                                    <rect key="frame" x="20" y="0.0" width="334" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1548,21 +1551,21 @@
                             <tableViewSection headerTitle="Developer" footerTitle="Yusaku is developer team organized by university students. We all have job hunting ❤️" id="ig8-lj-p2R">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="rzh-G5-F41" detailTextLabel="VNe-xg-qsV" style="IBUITableViewCellStyleValue1" id="dba-Hg-ajz">
-                                        <rect key="frame" x="16" y="224.33333206176758" width="343" height="43.5"/>
+                                        <rect key="frame" x="20" y="224.5" width="374" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="dba-Hg-ajz" id="Y35-mS-OvL">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Hayato Kohara" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="rzh-G5-F41">
-                                                    <rect key="frame" x="15" y="11.999999999999998" width="112" height="20.333333333333332"/>
+                                                    <rect key="frame" x="20" y="12" width="112" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="yaplus" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="VNe-xg-qsV">
-                                                    <rect key="frame" x="278.33333333333331" y="11.999999999999998" width="49.666666666666664" height="20.333333333333332"/>
+                                                    <rect key="frame" x="304.5" y="12" width="49.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1572,21 +1575,21 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="qhd-gx-0jQ" detailTextLabel="qIC-7T-9nv" style="IBUITableViewCellStyleValue1" id="kzg-bU-dZG">
-                                        <rect key="frame" x="16" y="267.83333206176758" width="343" height="43.5"/>
+                                        <rect key="frame" x="20" y="268" width="374" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="kzg-bU-dZG" id="yWl-bi-QPu">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Yuu Ichikawa" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="qhd-gx-0jQ">
-                                                    <rect key="frame" x="15" y="11.999999999999998" width="99" height="20.333333333333332"/>
+                                                    <rect key="frame" x="20" y="12" width="99" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="amylaseF85" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="qIC-7T-9nv">
-                                                    <rect key="frame" x="235.66666666666671" y="11.999999999999998" width="92.333333333333329" height="20.333333333333332"/>
+                                                    <rect key="frame" x="261.5" y="12" width="92.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1596,21 +1599,21 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="CPv-Cg-4t5" detailTextLabel="8ak-0M-dVi" style="IBUITableViewCellStyleValue1" id="cxx-2U-gni">
-                                        <rect key="frame" x="16" y="311.33333206176758" width="343" height="43.5"/>
+                                        <rect key="frame" x="20" y="311.5" width="374" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cxx-2U-gni" id="eXW-xo-7Dj">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Masahiro Nakamura" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="CPv-Cg-4t5">
-                                                    <rect key="frame" x="15" y="11.999999999999998" width="152.33333333333334" height="20.333333333333332"/>
+                                                    <rect key="frame" x="20" y="12" width="152.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="tsuu32" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="8ak-0M-dVi">
-                                                    <rect key="frame" x="274.33333333333331" y="11.999999999999998" width="53.666666666666664" height="20.333333333333332"/>
+                                                    <rect key="frame" x="300.5" y="12" width="53.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1620,21 +1623,21 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="4fa-q5-nKY" detailTextLabel="evX-1H-orG" style="IBUITableViewCellStyleValue1" id="Pbb-6s-rEH">
-                                        <rect key="frame" x="16" y="354.83333206176758" width="343" height="43.5"/>
+                                        <rect key="frame" x="20" y="355" width="374" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Pbb-6s-rEH" id="dA8-Aq-1ah">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Yuya Kiuchi" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="4fa-q5-nKY">
-                                                    <rect key="frame" x="15" y="11.999999999999998" width="88" height="20.333333333333332"/>
+                                                    <rect key="frame" x="20" y="12" width="88" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="bldsky" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="evX-1H-orG">
-                                                    <rect key="frame" x="277.66666666666669" y="11.999999999999998" width="50.333333333333336" height="20.333333333333332"/>
+                                                    <rect key="frame" x="303.5" y="12" width="50.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1648,21 +1651,21 @@
                             <tableViewSection headerTitle="Designer" id="Z5Y-0e-rAZ">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="YnT-gN-cvo" detailTextLabel="T4J-Wm-U4f" style="IBUITableViewCellStyleValue1" id="hJ2-1D-MRk">
-                                        <rect key="frame" x="16" y="482.33333206176758" width="343" height="43.5"/>
+                                        <rect key="frame" x="20" y="482.5" width="374" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hJ2-1D-MRk" id="QaB-Gu-Qx1">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Hayato Kohara" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="YnT-gN-cvo">
-                                                    <rect key="frame" x="15" y="11.999999999999998" width="112" height="20.333333333333332"/>
+                                                    <rect key="frame" x="20" y="12" width="112" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="yaplus.jp" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="T4J-Wm-U4f">
-                                                    <rect key="frame" x="260" y="11.999999999999998" width="68" height="20.333333333333332"/>
+                                                    <rect key="frame" x="286" y="12" width="68" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1695,7 +1698,7 @@
                     <tabBarItem key="tabBarItem" tag="2" title="Session" image="person.3.fill" catalog="system" id="TBi-Pu-CWv" userLabel="Member"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translucent="NO" id="8QL-15-Dut">
-                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" name="YusakuPinkColor"/>
                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -1718,14 +1721,14 @@
             <objects>
                 <viewController storyboardIdentifier="TutorialThirdViewController" id="GRp-2Z-1ou" customClass="TutorialThirdViewController" customModule="Juke" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="2SR-CR-0Le">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="TutorialPlay" translatesAutoresizingMaskIntoConstraints="NO" id="eIY-Gj-rtk">
-                                <rect key="frame" x="40" y="68" width="295" height="552.66666666666663"/>
+                                <rect key="frame" x="40" y="68" width="334" height="636.5"/>
                             </imageView>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="play.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="UUp-gZ-nQu">
-                                <rect key="frame" x="40" y="645.66666666666674" width="24" height="22"/>
+                                <rect key="frame" x="40" y="730" width="24" height="21.5"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="26.670000000000002" id="QE5-uL-V8w"/>
@@ -1734,7 +1737,7 @@
                                 <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="22"/>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Play Together." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="umK-U6-Lcw">
-                                <rect key="frame" x="76" y="644.66666666666663" width="259" height="24"/>
+                                <rect key="frame" x="76" y="728.5" width="298" height="24"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -1743,10 +1746,10 @@
                                 </variation>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wBs-aD-Utg">
-                                <rect key="frame" x="40" y="678" width="295" height="68"/>
+                                <rect key="frame" x="40" y="762" width="334" height="68"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="The &quot;requested&quot; songs will be played on the session master's device. Up to 8 people can participate in one session." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EON-EQ-VNj">
-                                        <rect key="frame" x="0.0" y="0.0" width="295" height="68"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="334" height="68"/>
                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
@@ -1801,11 +1804,11 @@
             <objects>
                 <viewController storyboardIdentifier="TutorialFourthViewController" id="Z3h-Xx-jlE" customClass="TutorialFourthViewController" customModule="Juke" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="kJm-KQ-82P">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eMj-i6-vVp">
-                                <rect key="frame" x="40" y="349" width="295" height="84"/>
+                                <rect key="frame" x="40" y="391" width="334" height="84"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="84" id="bhh-n9-Uim">
                                         <variation key="heightClass=regular-widthClass=regular" constant="68"/>
@@ -1820,7 +1823,7 @@
                                 </variation>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="battery.100" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="uUU-wa-eMQ">
-                                <rect key="frame" x="40" y="321.66666666666669" width="28" height="16.666666666666686"/>
+                                <rect key="frame" x="40" y="363.5" width="28" height="16.5"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="28" id="1Oq-ci-oa3"/>
@@ -1829,7 +1832,7 @@
                                 <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="20"/>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Battery Friendly." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l7E-cA-mWo">
-                                <rect key="frame" x="76" y="318" width="259" height="24"/>
+                                <rect key="frame" x="76" y="360" width="298" height="24"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -1838,7 +1841,7 @@
                                 </variation>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="When searching for a song to request, you can search by artist name, lyrics, or album name as well as the song name." lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QXG-aW-VbD">
-                                <rect key="frame" x="40" y="219" width="295" height="68"/>
+                                <rect key="frame" x="40" y="261" width="334" height="68"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="68" id="LUv-Zw-qPJ">
                                         <variation key="heightClass=regular-widthClass=regular" constant="68"/>
@@ -1852,7 +1855,7 @@
                                 </variation>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="magnifyingglass" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="l5f-Xq-55j">
-                                <rect key="frame" x="40" y="188" width="24" height="21.666666666666671"/>
+                                <rect key="frame" x="40" y="230.5" width="24" height="21"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="24" id="ive-Uo-PuV"/>
@@ -1861,7 +1864,7 @@
                                 <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="22"/>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Search Conveniently." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yYt-ve-v88">
-                                <rect key="frame" x="72" y="187" width="263" height="24"/>
+                                <rect key="frame" x="72" y="229" width="302" height="24"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -1870,7 +1873,7 @@
                                 </variation>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IVD-cF-rO5">
-                                <rect key="frame" x="40" y="497" width="295" height="84"/>
+                                <rect key="frame" x="40" y="539" width="334" height="84"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="84" id="DHX-ON-AeE">
                                         <variation key="heightClass=regular-widthClass=regular" constant="68"/>
@@ -1885,7 +1888,7 @@
                                 </variation>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="person.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="dCV-9l-vcM">
-                                <rect key="frame" x="40" y="467.33333333333331" width="22" height="20"/>
+                                <rect key="frame" x="40" y="509.5" width="22" height="19.5"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="22" id="IOe-jn-t0b"/>
@@ -1894,7 +1897,7 @@
                                 <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="24"/>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Self-Introduction." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="v2E-Cq-hjm">
-                                <rect key="frame" x="70" y="465" width="265" height="24"/>
+                                <rect key="frame" x="70" y="507" width="304" height="24"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -1903,7 +1906,7 @@
                                 </variation>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jyJ-Ze-gYI">
-                                <rect key="frame" x="75" y="718" width="225" height="44"/>
+                                <rect key="frame" x="83" y="802" width="248" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="fAK-Af-Vp2">
                                         <variation key="heightClass=regular-widthClass=regular" constant="64"/>
@@ -1988,7 +1991,7 @@
         <image name="JukeSleeping" width="512" height="512"/>
         <image name="Logo" width="256" height="100"/>
         <image name="LogoWhite" width="256" height="100"/>
-        <image name="SearchBarArrow" width="30" height="88.666664123535156"/>
+        <image name="SearchBarArrow" width="30" height="88.5"/>
         <image name="TemporarySingleColored" width="512" height="512"/>
         <image name="TutorialPlay" width="375" height="812"/>
         <image name="TutorialRequest" width="375" height="812"/>

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -1414,10 +1414,48 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
+                            <tableViewSection headerTitle="NowPlaying" footerTitle="When now-playing is enabled,  Now playing song is displayed in battery saver mode." id="lTj-NI-drX">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="GtC-eO-tiy">
+                                        <rect key="frame" x="20" y="508" width="374" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="GtC-eO-tiy" id="YN6-NC-6D7">
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="w17-nQ-FSf" userLabel="Is Now Playing Display In Battery Saver Mode Enabled Switch">
+                                                    <rect key="frame" x="305" y="6.5" width="49" height="31"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="31" id="U32-ou-24G"/>
+                                                        <constraint firstAttribute="width" constant="47" id="Zwp-nH-yag"/>
+                                                    </constraints>
+                                                    <color key="onTintColor" name="YusakuPinkColor"/>
+                                                    <connections>
+                                                        <action selector="isNowPlayingDisplayEnabledSwitchValueDidChange:" destination="Xlt-eI-mT8" eventType="valueChanged" id="Kvf-tR-RWT"/>
+                                                    </connections>
+                                                </switch>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Display Now-Playing" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aR4-UY-Y6a">
+                                                    <rect key="frame" x="15" y="11.5" width="344" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="aR4-UY-Y6a" firstAttribute="centerX" secondItem="YN6-NC-6D7" secondAttribute="centerX" id="JLo-Ie-hn9"/>
+                                                <constraint firstItem="aR4-UY-Y6a" firstAttribute="centerY" secondItem="YN6-NC-6D7" secondAttribute="centerY" id="P2v-nb-gf7"/>
+                                                <constraint firstItem="aR4-UY-Y6a" firstAttribute="leading" secondItem="YN6-NC-6D7" secondAttribute="leading" constant="15" id="X2J-r4-anQ"/>
+                                                <constraint firstAttribute="trailing" secondItem="w17-nQ-FSf" secondAttribute="trailing" constant="22" id="fH7-0N-45O"/>
+                                                <constraint firstItem="w17-nQ-FSf" firstAttribute="centerY" secondItem="YN6-NC-6D7" secondAttribute="centerY" id="gge-ba-MDE"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
                             <tableViewSection id="c1Y-Le-C7u">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="IKi-es-3Ji" style="IBUITableViewCellStyleDefault" id="5oP-6Y-muh">
-                                        <rect key="frame" x="20" y="480.5" width="374" height="43.5"/>
+                                        <rect key="frame" x="20" y="615.5" width="374" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="5oP-6Y-muh" id="Q0o-gm-JIS">
                                             <rect key="frame" x="0.0" y="0.0" width="343" height="43.5"/>
@@ -1447,6 +1485,7 @@
                     <navigationItem key="navigationItem" title="Settings" id="gio-Mw-drT"/>
                     <connections>
                         <outlet property="isAutoLockEnabledSwitch" destination="fCY-sL-Iuc" id="gbG-LZ-QGF"/>
+                        <outlet property="isNowPlayingDisplayEnabledSwitch" destination="w17-nQ-FSf" id="ia7-MP-lWT"/>
                         <outlet property="twitterAccountLabel" destination="Y5i-Fz-AZG" id="Q91-th-3wE"/>
                         <outlet property="userNameLabel" destination="Bl7-8g-a7O" id="VKY-0W-nYe"/>
                         <outlet property="willUseTwitterProfileSwitch" destination="u1w-l1-k2W" id="dez-90-UEc"/>

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -266,13 +266,13 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Logo" translatesAutoresizingMaskIntoConstraints="NO" id="LZr-FI-GlJ">
-                                <rect key="frame" x="87.666666666666686" y="181" width="200" height="200"/>
+                                <rect key="frame" x="87.666666666666686" y="231" width="200" height="100"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="200" id="Zh3-0L-qL5"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="© 2020 Yusaku" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S0h-WO-K7i">
-                                <rect key="frame" x="87.666666666666686" y="385" width="200" height="14.333333333333314"/>
+                                <rect key="frame" x="87.666666666666686" y="335" width="200" height="14.333333333333314"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -373,7 +373,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Juke allows you to make and play playlists by &quot;requesting&quot; songs to the other who subscribes to Apple Music." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bSx-NQ-Bh4">
-                                <rect key="frame" x="47" y="523" width="281" height="50.333333333333371"/>
+                                <rect key="frame" x="47" y="473" width="281" height="50.333333333333371"/>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -382,19 +382,19 @@
                                 </variation>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="LogoWhite" translatesAutoresizingMaskIntoConstraints="NO" id="Xcd-pM-qNx">
-                                <rect key="frame" x="91.666666666666686" y="311" width="192" height="200"/>
+                                <rect key="frame" x="91.666666666666686" y="361" width="192" height="100"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="192" id="oul-qf-lS9"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome to" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xjw-4N-jZQ">
-                                <rect key="frame" x="91.666666666666686" y="284.66666666666669" width="192" height="38.333333333333314"/>
+                                <rect key="frame" x="91.666666666666686" y="334.66666666666669" width="192" height="38.333333333333314"/>
                                 <fontDescription key="fontDescription" type="system" weight="thin" pointSize="32"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="BorderedAppIcon" translatesAutoresizingMaskIntoConstraints="NO" id="2EG-oP-0Cn">
-                                <rect key="frame" x="130.66666666666666" y="162.66666666666666" width="114" height="113.99999999999997"/>
+                                <rect key="frame" x="130.66666666666666" y="212.66666666666663" width="114" height="114"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="114" id="jcK-ri-F86"/>
                                     <constraint firstAttribute="width" constant="114" id="omu-p7-cfi"/>
@@ -856,6 +856,30 @@
                                     <constraint firstAttribute="trailing" secondItem="whP-AR-UDb" secondAttribute="trailing" id="bUV-rr-7iy"/>
                                 </constraints>
                             </view>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mcg-F5-Ag6" userLabel="Nowplaying View">
+                                <rect key="frame" x="40" y="271" width="295" height="280"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="T0H-AM-waI" userLabel="Artwork">
+                                        <rect key="frame" x="123" y="42" width="48" height="48"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="70q-sl-adH" userLabel="Artist">
+                                        <rect key="frame" x="35" y="170" width="224" height="28"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="28"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iZH-nQ-dgv" userLabel="Title">
+                                        <rect key="frame" x="35" y="126" width="224" height="28"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="28"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
@@ -872,7 +896,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="IbK-vi-r2D" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2624.6376811594205" y="-583.25892857142856"/>
+            <point key="canvasLocation" x="2623.1999999999998" y="-583.74384236453204"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="yl2-sM-qoP">

--- a/DJYusaku/BatterySaverViewController.swift
+++ b/DJYusaku/BatterySaverViewController.swift
@@ -74,7 +74,7 @@ class BatterySaverViewController: UIViewController {
     func animateFadeOut(view: UIView) {
         view.alpha = 1.0
         UIScreen.main.brightness = previousScreenBrightness
-        UIView.animate(withDuration: 2.0, delay: 1.0, animations: {
+        UIView.animate(withDuration: 2.0, delay: 1.0, options: [.allowUserInteraction], animations: {
             view.alpha = 0.0
         }, completion: { finished in
             if finished {
@@ -89,7 +89,7 @@ class BatterySaverViewController: UIViewController {
         prevView.alpha = 1.0
         nextView.alpha = 0.0
         UIScreen.main.brightness = previousScreenBrightness
-        UIView.animate(withDuration: 2.0, delay: 1.0, animations: {
+        UIView.animate(withDuration: 2.0, delay: 1.0, options: [.allowUserInteraction], animations: {
             prevView.alpha = 0.0
             nextView.alpha = 1.0
         }, completion: { finished in
@@ -145,7 +145,10 @@ class BatterySaverViewController: UIViewController {
     
     @objc func handleNowPlayingItemDidChange(){
         updateNowPlaying()
-        self.animateFadeOut(view: self.nowPlayingView)
+        if !(self.noteView.alpha > 0) {
+            self.animateFadeOut(view: self.nowPlayingView)
+        }
+
     }
     
     // ホームインジケータ(iPhone X以降)を非表示にする

--- a/DJYusaku/BatterySaverViewController.swift
+++ b/DJYusaku/BatterySaverViewController.swift
@@ -45,7 +45,6 @@ class BatterySaverViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.nowPlayingView.alpha = 0.0
         
         // 自動スリープをOFFにする
         UIApplication.shared.isIdleTimerDisabled = true
@@ -55,8 +54,10 @@ class BatterySaverViewController: UIViewController {
         
         // 注意書きと現在再生中の楽曲を表示してフェードアウトする
         if(PlayerQueue.shared.isQueueCreated){
-            self.animateDissolveAndFadeOut(prevView: self.noteView, nextView: self.nowPlayingView)
+            self.noteView.alpha = 0.0
+            self.animateFadeOut(view: self.nowPlayingView)
         }else{
+            self.nowPlayingView.alpha = 0.0
             self.animateFadeOut(view: self.noteView)
         }
     }
@@ -89,28 +90,6 @@ class BatterySaverViewController: UIViewController {
         })
     }
     
-    func animateDissolveAndFadeOut(prevView: UIView, nextView: UIView){
-        prevView.alpha = 1.0
-        nextView.alpha = 0.0
-        UIScreen.main.brightness = previousScreenBrightness
-        UIView.animate(withDuration: 2.0, delay: 1.0, options: [.allowUserInteraction], animations: {
-            prevView.alpha = 0.0
-            nextView.alpha = 1.0
-        }, completion: { dissolveFinished in
-            if dissolveFinished {
-                UIView.animate(withDuration: 2.0, delay: 1.0, options: [.allowUserInteraction], animations: {
-                    nextView.alpha = 0.0
-                }, completion: { fadeOutFinished in
-                    if fadeOutFinished {
-                        nextView.alpha = 0.0
-                        UIScreen.main.brightness = 0.0
-                    }
-                })
-            }
-        })
-    }
-    
-    // TODO:タッチイベントと被った時の処理
     private func updateNowPlaying(){
         let indexNowPlayingItem = PlayerQueue.shared.mpAppController.indexOfNowPlayingItem;
         if let nowPlayingSong = PlayerQueue.shared.get(at: indexNowPlayingItem) {
@@ -127,12 +106,12 @@ class BatterySaverViewController: UIViewController {
     
     // 画面のどこかしらがシングルタップされたら
     @objc func handleSingleTapeed(_ gesture: UITapGestureRecognizer) -> Void {
-//        self.noteView.layer.removeAllAnimations()
-//        self.nowPlayingView.layer.removeAllAnimations()
         // 注意書きと現在再生中の楽曲を表示してフェードアウトする
-        if(PlayerQueue.shared.isQueueCreated) {
-            self.animateDissolveAndFadeOut(prevView: self.noteView, nextView: self.nowPlayingView)
-        } else {
+        if(PlayerQueue.shared.isQueueCreated){
+            self.noteView.alpha = 0.0
+            self.animateFadeOut(view: self.nowPlayingView)
+        }else{
+            self.nowPlayingView.alpha = 0.0
             self.animateFadeOut(view: self.noteView)
         }
     }
@@ -152,9 +131,10 @@ class BatterySaverViewController: UIViewController {
         
         // 注意書きと現在再生中の楽曲を表示してフェードアウトする
         if(PlayerQueue.shared.isQueueCreated){
-//            if(self.nowPlayingView.alpha > 0.0)
-            self.animateDissolveAndFadeOut(prevView: self.noteView, nextView: self.nowPlayingView)
+            self.noteView.alpha = 0.0
+            self.animateFadeOut(view: self.nowPlayingView)
         }else{
+            self.nowPlayingView.alpha = 0.0
             self.animateFadeOut(view: self.noteView)
         }
     }
@@ -170,10 +150,8 @@ class BatterySaverViewController: UIViewController {
         self.noteView.layer.removeAllAnimations()
         self.nowPlayingView.layer.removeAllAnimations()
         updateNowPlaying()
-        if !(self.noteView.alpha > 0) {
-            self.animateFadeOut(view: self.nowPlayingView)
-        }
-
+        self.noteView.alpha = 0.0
+        self.animateFadeOut(view: self.nowPlayingView)
     }
     
     // ホームインジケータ(iPhone X以降)を非表示にする

--- a/DJYusaku/BatterySaverViewController.swift
+++ b/DJYusaku/BatterySaverViewController.swift
@@ -45,6 +45,7 @@ class BatterySaverViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.nowPlayingView.alpha = 0.0
         
         // 自動スリープをOFFにする
         UIApplication.shared.isIdleTimerDisabled = true
@@ -79,11 +80,16 @@ class BatterySaverViewController: UIViewController {
         view.alpha = 1.0
         UIScreen.main.brightness = previousScreenBrightness
         UIView.animate(withDuration: 2.0, delay: 1.0, options: [.allowUserInteraction], animations: {
+            print("animateFadeOut: Start")
             view.alpha = 0.0
         }, completion: { finished in
             if finished {
                 view.alpha = 0.0
                 UIScreen.main.brightness = 0.0
+                print("animateFadeOut: Finished")
+            }else{
+                view.alpha = 0.0
+                print("animateFadeOut: Not Finished")
             }
         })
     }
@@ -93,11 +99,17 @@ class BatterySaverViewController: UIViewController {
         nextView.alpha = 0.0
         UIScreen.main.brightness = previousScreenBrightness
         UIView.animate(withDuration: 2.0, delay: 1.0, options: [.allowUserInteraction], animations: {
+            print("animateDissolveAndFadeOut: Start")
             prevView.alpha = 0.0
             nextView.alpha = 1.0
         }, completion: { finished in
             if finished {
                 self.animateFadeOut(view: nextView)
+                print("animateDissolveAndFadeOut: Finished")
+            }else{
+                prevView.alpha = 0.0
+                nextView.alpha = 0.0
+                print("animateDissolveAndFadeOut: Not Finished")
             }
         })
     }
@@ -119,6 +131,8 @@ class BatterySaverViewController: UIViewController {
     
     // 画面のどこかしらがシングルタップされたら
     @objc func handleSingleTapeed(_ gesture: UITapGestureRecognizer) -> Void {
+        self.noteView.layer.removeAllAnimations()
+        self.nowPlayingView.layer.removeAllAnimations()
         // 注意書きと現在再生中の楽曲を表示してフェードアウトする
         if(PlayerQueue.shared.isQueueCreated){
             self.animateDissolveAndFadeOut(prevView: self.noteView, nextView: self.nowPlayingView)
@@ -156,6 +170,8 @@ class BatterySaverViewController: UIViewController {
     
     //NowPlayingの内容が変わったら更新して再表示
     @objc func handleNowPlayingItemDidChange(){
+        self.noteView.layer.removeAllAnimations()
+        self.nowPlayingView.layer.removeAllAnimations()
         updateNowPlaying()
         if !(self.noteView.alpha > 0) {
             self.animateFadeOut(view: self.nowPlayingView)

--- a/DJYusaku/BatterySaverViewController.swift
+++ b/DJYusaku/BatterySaverViewController.swift
@@ -53,7 +53,11 @@ class BatterySaverViewController: UIViewController {
         self.previousScreenBrightness = UIScreen.main.brightness
         
         // 注意書きと現在再生中の楽曲を表示してフェードアウトする
-        self.animateDissolveAndFadeOut(prevView: self.noteView, nextView: self.nowPlayingView)
+        if(PlayerQueue.shared.isQueueCreated){
+            self.animateDissolveAndFadeOut(prevView: self.noteView, nextView: self.nowPlayingView)
+        }else{
+            self.animateFadeOut(view: self.noteView)
+        }
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -84,7 +88,6 @@ class BatterySaverViewController: UIViewController {
         })
     }
     
-    // TODO:ディゾルブのメソッドに直す
     func animateDissolveAndFadeOut(prevView: UIView, nextView: UIView){
         prevView.alpha = 1.0
         nextView.alpha = 0.0
@@ -117,7 +120,11 @@ class BatterySaverViewController: UIViewController {
     // 画面のどこかしらがシングルタップされたら
     @objc func handleSingleTapeed(_ gesture: UITapGestureRecognizer) -> Void {
         // 注意書きと現在再生中の楽曲を表示してフェードアウトする
-        self.animateDissolveAndFadeOut(prevView: self.noteView, nextView: self.nowPlayingView)
+        if(PlayerQueue.shared.isQueueCreated){
+            self.animateDissolveAndFadeOut(prevView: self.noteView, nextView: self.nowPlayingView)
+        }else{
+            self.animateFadeOut(view: self.noteView)
+        }
     }
 
     // 画面のどこかしらがダブルタップされたら
@@ -134,7 +141,11 @@ class BatterySaverViewController: UIViewController {
         self.previousScreenBrightness = UIScreen.main.brightness
         
         // 注意書きと現在再生中の楽曲を表示してフェードアウトする
-        self.animateDissolveAndFadeOut(prevView: self.noteView, nextView: self.nowPlayingView)
+        if(PlayerQueue.shared.isQueueCreated){
+            self.animateDissolveAndFadeOut(prevView: self.noteView, nextView: self.nowPlayingView)
+        }else{
+            self.animateFadeOut(view: self.noteView)
+        }
     }
     
     // アプリがアクティブじゃなくなる（例：ホーム画面に戻る）とき
@@ -143,6 +154,7 @@ class BatterySaverViewController: UIViewController {
         UIScreen.main.brightness = previousScreenBrightness // 画面の明るさを復元する
     }
     
+    //NowPlayingの内容が変わったら更新して再表示
     @objc func handleNowPlayingItemDidChange(){
         updateNowPlaying()
         if !(self.noteView.alpha > 0) {

--- a/DJYusaku/BatterySaverViewController.swift
+++ b/DJYusaku/BatterySaverViewController.swift
@@ -99,6 +99,7 @@ class BatterySaverViewController: UIViewController {
         })
     }
     
+    // TODO:タッチイベントと被った時の処理
     private func updateNowPlaying(){
         let indexNowPlayingItem = PlayerQueue.shared.mpAppController.indexOfNowPlayingItem;
         if let nowPlayingSong = PlayerQueue.shared.get(at: indexNowPlayingItem) {

--- a/DJYusaku/BatterySaverViewController.swift
+++ b/DJYusaku/BatterySaverViewController.swift
@@ -79,17 +79,12 @@ class BatterySaverViewController: UIViewController {
     func animateFadeOut(view: UIView) {
         view.alpha = 1.0
         UIScreen.main.brightness = previousScreenBrightness
-        UIView.animate(withDuration: 2.0, delay: 1.0, options: [.allowUserInteraction], animations: {
-            print("animateFadeOut: Start")
+        UIView.animate(withDuration: 2.0, delay: 1.0, animations: {
             view.alpha = 0.0
         }, completion: { finished in
             if finished {
                 view.alpha = 0.0
                 UIScreen.main.brightness = 0.0
-                print("animateFadeOut: Finished")
-            }else{
-                view.alpha = 0.0
-                print("animateFadeOut: Not Finished")
             }
         })
     }
@@ -99,17 +94,18 @@ class BatterySaverViewController: UIViewController {
         nextView.alpha = 0.0
         UIScreen.main.brightness = previousScreenBrightness
         UIView.animate(withDuration: 2.0, delay: 1.0, options: [.allowUserInteraction], animations: {
-            print("animateDissolveAndFadeOut: Start")
             prevView.alpha = 0.0
             nextView.alpha = 1.0
-        }, completion: { finished in
-            if finished {
-                self.animateFadeOut(view: nextView)
-                print("animateDissolveAndFadeOut: Finished")
-            }else{
-                prevView.alpha = 0.0
-                nextView.alpha = 0.0
-                print("animateDissolveAndFadeOut: Not Finished")
+        }, completion: { dissolveFinished in
+            if dissolveFinished {
+                UIView.animate(withDuration: 2.0, delay: 1.0, options: [.allowUserInteraction], animations: {
+                    nextView.alpha = 0.0
+                }, completion: { fadeOutFinished in
+                    if fadeOutFinished {
+                        nextView.alpha = 0.0
+                        UIScreen.main.brightness = 0.0
+                    }
+                })
             }
         })
     }
@@ -131,12 +127,12 @@ class BatterySaverViewController: UIViewController {
     
     // 画面のどこかしらがシングルタップされたら
     @objc func handleSingleTapeed(_ gesture: UITapGestureRecognizer) -> Void {
-        self.noteView.layer.removeAllAnimations()
-        self.nowPlayingView.layer.removeAllAnimations()
+//        self.noteView.layer.removeAllAnimations()
+//        self.nowPlayingView.layer.removeAllAnimations()
         // 注意書きと現在再生中の楽曲を表示してフェードアウトする
-        if(PlayerQueue.shared.isQueueCreated){
+        if(PlayerQueue.shared.isQueueCreated) {
             self.animateDissolveAndFadeOut(prevView: self.noteView, nextView: self.nowPlayingView)
-        }else{
+        } else {
             self.animateFadeOut(view: self.noteView)
         }
     }
@@ -156,6 +152,7 @@ class BatterySaverViewController: UIViewController {
         
         // 注意書きと現在再生中の楽曲を表示してフェードアウトする
         if(PlayerQueue.shared.isQueueCreated){
+//            if(self.nowPlayingView.alpha > 0.0)
             self.animateDissolveAndFadeOut(prevView: self.noteView, nextView: self.nowPlayingView)
         }else{
             self.animateFadeOut(view: self.noteView)

--- a/DJYusaku/BatterySaverViewController.swift
+++ b/DJYusaku/BatterySaverViewController.swift
@@ -11,6 +11,10 @@ import UIKit
 class BatterySaverViewController: UIViewController {
     
     @IBOutlet weak var noteView: UIView!
+    @IBOutlet weak var nowplayingView: UIView!
+    @IBOutlet weak var nowplayingArtwork: UIImageView!
+    @IBOutlet weak var nowplayingArtist: UILabel!
+    @IBOutlet weak var nowplayingTitle: UILabel!
     private var previousScreenBrightness : CGFloat = 0.0    // 元の画面の明るさ
     
     override func viewDidLoad() {
@@ -45,7 +49,9 @@ class BatterySaverViewController: UIViewController {
         self.previousScreenBrightness = UIScreen.main.brightness
         
         // 注意書きを表示してフェードアウトする
+        self.nowplayingView.alpha = 0
         self.animateFadeOut(view: self.noteView)
+        self.animateFadeOut(view: self.nowplayingView)
     }
     
     override func viewWillDisappear(_ animated: Bool) {

--- a/DJYusaku/BatterySaverViewController.swift
+++ b/DJYusaku/BatterySaverViewController.swift
@@ -48,10 +48,8 @@ class BatterySaverViewController: UIViewController {
         // 元の画面の明るさを記録しておく
         self.previousScreenBrightness = UIScreen.main.brightness
         
-        // 注意書きを表示してフェードアウトする
-        self.nowplayingView.alpha = 0
-        self.animateFadeOut(view: self.noteView)
-        self.animateFadeOut(view: self.nowplayingView)
+        // 注意書きと現在再生中の楽曲を表示してフェードアウトする
+        self.animateDissolveAndFadeOut(prevView: self.noteView, nextView: self.nowplayingView)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -82,10 +80,24 @@ class BatterySaverViewController: UIViewController {
         })
     }
     
+    func animateDissolveAndFadeOut(prevView: UIView, nextView: UIView){
+        prevView.alpha = 1.0
+        nextView.alpha = 0.0
+        UIScreen.main.brightness = previousScreenBrightness
+        UIView.animate(withDuration: 2.0, delay: 1.0, animations: {
+            prevView.alpha = 0.0
+            nextView.alpha = 1.0
+        }, completion: { finished in
+            if finished {
+                self.animateFadeOut(view: nextView)
+            }
+        })
+    }
+    
     // 画面のどこかしらがシングルタップされたら
     @objc func handleSingleTapeed(_ gesture: UITapGestureRecognizer) -> Void {
-        // 注意書きを表示してフェードアウトする
-        self.animateFadeOut(view: self.noteView)
+        // 注意書きと現在再生中の楽曲を表示してフェードアウトする
+        self.animateDissolveAndFadeOut(prevView: self.noteView, nextView: self.nowplayingView)
     }
 
     // 画面のどこかしらがダブルタップされたら
@@ -101,8 +113,8 @@ class BatterySaverViewController: UIViewController {
         // 元の画面の明るさを記録しておく
         self.previousScreenBrightness = UIScreen.main.brightness
         
-        // 注意書きを表示してフェードアウトする
-        self.animateFadeOut(view: self.noteView)
+        // 注意書きと現在再生中の楽曲を表示してフェードアウトする
+        self.animateDissolveAndFadeOut(prevView: self.noteView, nextView: self.nowplayingView)
     }
     
     // アプリがアクティブじゃなくなる（例：ホーム画面に戻る）とき

--- a/DJYusaku/BatterySaverViewController.swift
+++ b/DJYusaku/BatterySaverViewController.swift
@@ -53,7 +53,7 @@ class BatterySaverViewController: UIViewController {
         self.previousScreenBrightness = UIScreen.main.brightness
         
         // 注意書きと現在再生中の楽曲を表示してフェードアウトする
-        if(PlayerQueue.shared.isQueueCreated){
+        if(PlayerQueue.shared.isQueueCreated && DefaultsController.shared.isNowPlayingDisplayEnabled){
             self.noteView.alpha = 0.0
             self.animateFadeOut(view: self.nowPlayingView)
         }else{
@@ -107,7 +107,7 @@ class BatterySaverViewController: UIViewController {
     // 画面のどこかしらがシングルタップされたら
     @objc func handleSingleTapeed(_ gesture: UITapGestureRecognizer) -> Void {
         // 注意書きと現在再生中の楽曲を表示してフェードアウトする
-        if(PlayerQueue.shared.isQueueCreated){
+        if(PlayerQueue.shared.isQueueCreated && DefaultsController.shared.isNowPlayingDisplayEnabled){
             self.noteView.alpha = 0.0
             self.animateFadeOut(view: self.nowPlayingView)
         }else{
@@ -130,7 +130,7 @@ class BatterySaverViewController: UIViewController {
         self.previousScreenBrightness = UIScreen.main.brightness
         
         // 注意書きと現在再生中の楽曲を表示してフェードアウトする
-        if(PlayerQueue.shared.isQueueCreated){
+        if(PlayerQueue.shared.isQueueCreated && DefaultsController.shared.isNowPlayingDisplayEnabled){
             self.noteView.alpha = 0.0
             self.animateFadeOut(view: self.nowPlayingView)
         }else{
@@ -147,11 +147,13 @@ class BatterySaverViewController: UIViewController {
     
     //NowPlayingの内容が変わったら更新して再表示
     @objc func handleNowPlayingItemDidChange(){
-        self.noteView.layer.removeAllAnimations()
-        self.nowPlayingView.layer.removeAllAnimations()
-        updateNowPlaying()
-        self.noteView.alpha = 0.0
-        self.animateFadeOut(view: self.nowPlayingView)
+        if(DefaultsController.shared.isNowPlayingDisplayEnabled){
+            self.noteView.layer.removeAllAnimations()
+            self.nowPlayingView.layer.removeAllAnimations()
+            updateNowPlaying()
+            self.noteView.alpha = 0.0
+            self.animateFadeOut(view: self.nowPlayingView)
+        }
     }
     
     // ホームインジケータ(iPhone X以降)を非表示にする

--- a/DJYusaku/DefaultsController.swift
+++ b/DJYusaku/DefaultsController.swift
@@ -35,12 +35,14 @@ class DefaultsController: NSObject {
     private(set) var profile: PeerProfile = PeerProfile(name: UIDevice.current.name, imageUrl: nil)
     private(set) var willUseTwitterProfile : Bool = false
     private(set) var isAutoLockEnabled : Bool = true
+    private(set) var isNowPlayingDisplayEnabled: Bool = true
     
     private override init() {
         super.init()
         
         // UserDefaultsに初期値を設定する
         UserDefaults.standard.register(defaults: [UserDefaults.DJYusakuDefaults.IsAutoLockEnabled : true])
+        UserDefaults.standard.register(defaults: [UserDefaults.DJYusakuDefaults.IsNowPlayingDisplayEnabled : true])
         
         // UserDefaultsの変更を監視する
         NotificationCenter.default.addObserver(self,
@@ -79,6 +81,9 @@ class DefaultsController: NSObject {
         DispatchQueue.main.async {
             UIApplication.shared.isIdleTimerDisabled = !self.isAutoLockEnabled
         }
+        
+        // 省電力モードでNowPlayingを表示するかを設定する
+        self.isNowPlayingDisplayEnabled = UserDefaults.standard.bool(forKey: UserDefaults.DJYusakuDefaults.IsNowPlayingDisplayEnabled)
         
         self.sendProfile()  // プロフィールを他のピアに送信する
     }

--- a/DJYusaku/SettingsViewController.swift
+++ b/DJYusaku/SettingsViewController.swift
@@ -25,6 +25,8 @@ class SettingsViewController: UITableViewController, SFSafariViewControllerDeleg
     @IBOutlet weak var twitterAccountLabel: UILabel!
     @IBOutlet weak var willUseTwitterProfileSwitch: UISwitch!
     @IBOutlet weak var isAutoLockEnabledSwitch: UISwitch!
+    @IBOutlet weak var isNowPlayingDisplayEnabledSwitch: UISwitch!
+    
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -58,6 +60,9 @@ class SettingsViewController: UITableViewController, SFSafariViewControllerDeleg
     @IBAction func isAutoLockEnabledSwitchValueDidChange(_ sender: UISwitch) {
         UserDefaults.standard.set(sender.isOn, forKey: UserDefaults.DJYusakuDefaults.IsAutoLockEnabled)
     }
+    @IBAction func isNowPlayingDisplayEnabledSwitchValueDidChange(_ sender: UISwitch) {
+        UserDefaults.standard.set(sender.isOn, forKey: UserDefaults.DJYusakuDefaults.IsNowPlayingDisplayEnabled)
+    }
     
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return UIStatusBarStyle.lightContent
@@ -78,7 +83,9 @@ class SettingsViewController: UITableViewController, SFSafariViewControllerDeleg
             self.tableViewTwitterSection(at: indexPath.row)
         case 2: // Auto-Lock
             break
-        case 3: // About This App
+        case 3: // NowPlaying
+            break
+        case 4: // About This App
             break
         default:
             break

--- a/DJYusaku/UserDefaults+DJYusakuDefaults.swift
+++ b/DJYusaku/UserDefaults+DJYusakuDefaults.swift
@@ -10,12 +10,13 @@ import UIKit
 
 extension UserDefaults {
     class DJYusakuDefaults {
-        static let ProfileName           = "ProfileName"
-        static let TwitterAccount        = "TwitterAccount"
-        static let WillUseTwitterProfile = "WillUseTwitterProfile"
-        static let IsAutoLockEnabled     = "IsAutoLockEnabled"
-        static let IsLaunchedAtLeastOnce = "IsLaunchedAtLeastOnce"
-        static let LaunchCount           = "LaunchCount"
-        static let ArchivedPeerID        = "ArchivedPeerID"
+        static let ProfileName                = "ProfileName"
+        static let TwitterAccount             = "TwitterAccount"
+        static let WillUseTwitterProfile      = "WillUseTwitterProfile"
+        static let IsAutoLockEnabled          = "IsAutoLockEnabled"
+        static let IsLaunchedAtLeastOnce      = "IsLaunchedAtLeastOnce"
+        static let LaunchCount                = "LaunchCount"
+        static let ArchivedPeerID             = "ArchivedPeerID"
+        static let IsNowPlayingDisplayEnabled = "isNowPlayingDisplayEnabled"
     }
 }

--- a/DJYusaku/ja.lproj/Main.strings
+++ b/DJYusaku/ja.lproj/Main.strings
@@ -221,9 +221,6 @@
 /* Class = "UILabel"; text = "To exit battery saver mode, double-tap the screen."; ObjectID = "whP-AR-UDb"; */
 "whP-AR-UDb.text" = "画面をダブルタップすると、 省電力モードを終了します。";
 
-/* Class = "UILabel"; text = "To exit battery saver mode, double-tap the screen."; ObjectID = "7II-4V-DS7"; */
-"7II-4V-DS7.text" = "画面をダブルタップすると、 省電力モードを終了します。";
-
 /* Class = "UILabel"; text = "Name"; ObjectID = "yP3-9N-fvb"; */
 "yP3-9N-fvb.text" = "名前";
 

--- a/DJYusaku/ja.lproj/Main.strings
+++ b/DJYusaku/ja.lproj/Main.strings
@@ -221,6 +221,9 @@
 /* Class = "UILabel"; text = "To exit battery saver mode, double-tap the screen."; ObjectID = "whP-AR-UDb"; */
 "whP-AR-UDb.text" = "画面をダブルタップすると、 省電力モードを終了します。";
 
+/* Class = "UILabel"; text = "To exit battery saver mode, double-tap the screen."; ObjectID = "7II-4V-DS7"; */
+"7II-4V-DS7.text" = "画面をダブルタップすると、 省電力モードを終了します。";
+
 /* Class = "UILabel"; text = "Name"; ObjectID = "yP3-9N-fvb"; */
 "yP3-9N-fvb.text" = "名前";
 


### PR DESCRIPTION
## 概要
これまでは省電力モードにはジューくんと注意書きが表示されるだけであったが、
ここに再生中の楽曲が表示されると、運転中に簡単に確認できるため機能を追加した。

## 追加・変更点
- 省電力モード中、再生中の楽曲のアートワーク、曲名、アーティスト名、さらに省電力モードから戻る方法が書かれている注意書きを表示
       - 再生キュー内に何もない（isQueueCreated: false）の時は元来のジューくんと注意書きを表示
       - 履歴の紆余曲折もあったので既存のビューを改造するのではなく、新しく別のビューを追加する方法をとった
- この機能が必要ない人向けに、楽曲情報の表示/非表示を切り替えるスイッチを設定画面に追加
       - デフォルトは表示
       - 非表示にすると以前と同じように元来のジューくんと注意書き
       - 設定はUserDefaultsに記録される

## 動作確認
少なくとも以下でちゃんと表示されたり、表示が崩れないことを確認してください（こちらでは確認済）
- 曲の再生途中でシングルタップ
- 再生中の曲が切り替わる時にタップ
- 設定でオフにした時に誤ってNowplayingが表示されないか

## 問題点
- 新しく追加したNowPlayingViewが表示されている時は、タップ操作が効かない
Storyboardで、UserInteractionEnabledにチェックは入っている

- ローカライズしてない　Main.stringsをいじろうと思ったがこれは手動でいじるべきではないと思い戻した

2点が解決したらDraft外します